### PR TITLE
fix(sftp): handle JSch IOException('inputstream is closed') with channel reset and retry

### DIFF
--- a/core/ssh/src/main/kotlin/sh/haven/core/ssh/sftp/JschSftpSession.kt
+++ b/core/ssh/src/main/kotlin/sh/haven/core/ssh/sftp/JschSftpSession.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import sh.haven.core.ssh.SshIoException
 import java.io.InputStream
+import java.io.IOException
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -24,6 +25,15 @@ import java.util.concurrent.atomic.AtomicReference
  * to [SshIoException] so callers do not need to import JSch types.
  */
 internal class JschSftpSession(private val channel: ChannelSftp) : SftpSession {
+
+    init {
+        // Limit per-request bulk size to reduce the likelihood of JSch's
+        // ChannelSftp.fill() throwing IOException("inputstream is closed")
+        // on VM SSH servers that fragment SFTP response packets.
+        // The default bulk size triggers the issue more readily on Android +
+        // local VM combinations (mwiede/jsch#858).
+        channel.setBulkSize(BULK_SIZE)
+    }
 
     override val isConnected: Boolean
         get() = channel.isConnected
@@ -198,10 +208,21 @@ internal class JschSftpSession(private val channel: ChannelSftp) : SftpSession {
         throw SshIoException(e.message, e)
     } catch (e: JSchException) {
         throw SshIoException(e.message, e)
+    } catch (e: IOException) {
+        throw SshIoException(e.message, e)
     }
 
     private companion object {
         /** Pipe capacity for the streamed SFTP download (back-pressures the producer). */
         const val PIPE_BUFFER_BYTES = 1 shl 20 // 1 MiB
+
+        /**
+         * Max bytes per SFTP read/write request. Smaller values reduce the
+         * chance of JSch's internal [ChannelSftp.fill] misinterpreting a
+         * fragmented response as a closed stream, particularly against VM
+         * SSH servers on Android. 16 KiB is conservative — performance
+         * impact is negligible for directory listings and small transfers.
+         */
+        const val BULK_SIZE = 16 * 1024 // 16 KiB
     }
 }

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -4622,6 +4622,20 @@ class SftpViewModel @Inject constructor(
                 val results = transport.list(landing)
                 _allEntries.value = sortEntries(results, _sortMode.value)
                 applyFilter()
+            } catch (e: SshIoException) {
+                Log.w(TAG, "SFTP open failed; resetting channel and retrying", e)
+                resetSftpChannel()
+                try {
+                    val transport = currentSshTransport()
+                        ?: throw IllegalStateException("Session not connected after reset")
+                    val landing = _currentPath.value
+                    val results = transport.list(landing)
+                    _allEntries.value = sortEntries(results, _sortMode.value)
+                    applyFilter()
+                } catch (e2: Exception) {
+                    Log.e(TAG, "SFTP open failed after retry", e2)
+                    _error.value = "SFTP connection lost — please try again"
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "SFTP open failed", e)
                 _error.value = "File browser failed: ${e.message}"
@@ -4710,6 +4724,23 @@ class SftpViewModel @Inject constructor(
                     Log.w(TAG, "SFTP channel corrupt at path='$path'; resetting", e)
                     resetSftpChannel()
                     _error.value = "SFTP channel error — please try again"
+                } catch (e: SshIoException) {
+                    // JSch's ChannelSftp.fill() throws IOException("inputstream is closed")
+                    // when the underlying stream read returns <= 0 — a transient
+                    // connection glitch or a slow server (mwiede/jsch#858). Reset the
+                    // channel and retry once before surfacing the error to the user.
+                    Log.w(TAG, "SFTP list failed at path='$path'; resetting and retrying", e)
+                    resetSftpChannel()
+                    try {
+                        val backend = currentFileBackend()
+                            ?: throw IllegalStateException("Not connected after reset")
+                        val results = backend.list(path)
+                        _allEntries.value = sortEntries(results, _sortMode.value)
+                        applyFilter()
+                    } catch (e2: Exception) {
+                        Log.e(TAG, "List directory failed after retry: path='$path'", e2)
+                        _error.value = "SFTP connection lost — please try again"
+                    }
                 } catch (e: Exception) {
                     Log.e(TAG, "List directory failed: path='$path'", e)
                     _error.value = "Failed to list: ${e.message}"


### PR DESCRIPTION
Fix for the `Failed to list: java.io.IOException: inputstream is closed` error when connecting to folders, particularly on local VM SSH servers.

**Changes:**

1. **JschSftpSession** — Add `IOException` catch to `translatingJschErrors()` so JSch's raw IOExceptions are wrapped in `SshIoException` instead of propagating through
2. **JschSftpSession** — Call `channel.setBulkSize(16KB)` in init to reduce fragmentation-triggered `fill()` failures on VM SSH servers (mwiede/jsch#858)
3. **SftpViewModel** — Catch `SshIoException` in `loadDirectoryEntries()` and `openSftpAndList()`, reset the corrupted SFTP channel, and retry once before surfacing error to the user

**Root cause:** JSch's `ChannelSftp.fill()` throws `IOException("inputstream is closed")` when `io_in.read()` returns `<= 0`, which can happen with fragmented SFTP responses, VM SSH servers, or Android socket behavior differences. The JSch library has a known issue (mwiede/jsch#858) with this behavior.