### PR TITLE
fix(sftp): catch pre-warm SFTP session failure in selectProfile cached branch

### DIFF
--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -1440,7 +1440,11 @@ class SftpViewModel @Inject constructor(
                 isReticulum -> { /* backend resolved on demand via TransportSelector */ }
                 else -> {
                     viewModelScope.launch(Dispatchers.IO) {
-                        sftpSession = sessionManager.openSftpSession(profileId)
+                        try {
+                            sftpSession = sessionManager.openSftpSession(profileId)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to pre-warm SFTP session for $profileId", e)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Follow-up to #412.

**Problem:** The cached profile branch in `selectProfile()` launches a fire-and-forget coroutine to pre-warm the SFTP session, but JSch's `ChannelSftp` can throw `IOException("inputstream is closed")` during the INIT handshake (mwiede/jsch#858). Without a try-catch, this propagates to the uncaught exception handler and crashes the app.

**Fix:** Add try-catch matching the existing codebase pattern (same as the rclone capabilities pre-warm at the same call site). The failure is logged and silently swallowed — the next explicit operation (`openSftpAndList` / `loadDirectoryEntries`) will open a fresh session with proper error/retry handling.

**Root cause:** PR #412 fixed `openSftpAndList` and `loadDirectoryEntries` but missed the fire-and-forget pre-warm coroutine on line 1442.
