### PR TITLE
feat(terminal): floating text input dialog (ported from ConnectBot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ the corresponding GitHub Release; a release can't ship without its section
 (enforced by `scripts/check-changelog.sh` in CI). The GitHub "Full Changelog"
 compare link is appended automatically — don't add it here.
 
+## v5.82.0
+
+⌨️ **Terminal: floating text input** — a new toolbar key opens a draggable, resizable text box floating over the terminal, so you can compose a whole command with your normal keyboard (autocorrect, swipe typing, voice input, cursor movement) and send it in one shot, instead of fighting the raw terminal cell character-by-character. Embedded newlines and tabs show inline as ↩ / ⇥ so you can see exactly what will be sent, and the text is bracketed-paste-wrapped on send, so a multi-line block arrives as a paste instead of executing line-by-line. Unsent drafts are kept per tab and survive rotation; the window position/size is remembered. The key sits on the default toolbar and can be moved/hidden like any other key. Ported from ConnectBot's Text Input dialog (Apache-2.0).
+
 ## v5.81.6
 
 🖱️ **Terminal: touchpad two-finger scroll on some tablets** — on certain OEM tablets (reported on OPPO Pad 3 Pro) a Bluetooth-keyboard touchpad's two-finger scroll moved the app's own lists but did nothing in the terminal. Those touchpad drivers only send a scroll to a view that advertises itself as scrollable, which the terminal wasn't doing. The terminal now declares vertical scroll semantics (a mouse wheel already worked), which should route the gesture through — and, as a bonus, makes the terminal scrollable to TalkBack. Candidate fix, since I can't reproduce it here — feedback welcome. (#419, thanks wxjiee)

--- a/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
+++ b/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
@@ -25,7 +25,7 @@ object ConnectDeepLink {
         val transport: String?,
         val session: String?,
         /** Optional remote command (Tin attach / clean tmux). `command` or `startupCommand` query. */
-        val command: String?,
+        val command: String? = null,
     )
 
     /**

--- a/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
+++ b/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
@@ -24,6 +24,8 @@ object ConnectDeepLink {
         /** `ssh` / `mosh` / `et`, or null when the link didn't specify one. */
         val transport: String?,
         val session: String?,
+        /** Optional remote command (Tin attach / clean tmux). `command` or `startupCommand` query. */
+        val command: String?,
     )
 
     /**
@@ -39,6 +41,7 @@ object ConnectDeepLink {
             port = query("port")?.trim()?.toIntOrNull(),
             transport = query("transport")?.trim()?.lowercase()?.takeIf { it.isNotEmpty() },
             session = query("session")?.trim()?.takeIf { it.isNotEmpty() },
+            command = (query("command") ?: query("startupCommand"))?.trim()?.takeIf { it.isNotEmpty() },
         )
     }
 
@@ -69,7 +72,7 @@ object ConnectDeepLink {
     fun resolve(profiles: List<ConnectionProfile>, p: Params): AgentUiCommand {
         val match = matches(profiles, p).singleOrNull()
         return if (match != null) {
-            AgentUiCommand.ConnectFromDeepLink(match.id, p.session)
+            AgentUiCommand.ConnectFromDeepLink(match.id, p.session, p.command)
         } else {
             AgentUiCommand.PrefillNewConnection(p.host, p.username, p.port, p.transport ?: "ssh", p.session)
         }

--- a/core/data/src/main/kotlin/sh/haven/core/data/agent/AgentUiCommand.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/agent/AgentUiCommand.kt
@@ -194,6 +194,8 @@ sealed class AgentUiCommand {
     data class ConnectFromDeepLink(
         val profileId: String,
         val sessionName: String? = null,
+        /** Optional remote command (e.g. tmux attach) — mosh path uses mosh-server `-- COMMAND`. */
+        val startupCommand: String? = null,
     ) : AgentUiCommand()
 
     /**

--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/ToolbarKey.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/ToolbarKey.kt
@@ -11,6 +11,7 @@ enum class ToolbarKey(val id: String, val label: String, val isModifier: Boolean
     TAB_KEY("tab", "Tab", isAction = true),
     ENTER_KEY("enter", "Enter", isAction = true),
     PASTE("paste", "Paste", isAction = true),
+    TEXT_INPUT("text_input", "Text input", isAction = true),
     SNIPPETS("snippets", "Snippets", isAction = true),
     ATTACH("attach", "Attach", isAction = true),
     VOICE_KEYBOARD("voice_kb", "Voice", isAction = true),
@@ -93,7 +94,7 @@ enum class ToolbarKey(val id: String, val label: String, val isModifier: Boolean
 
         /** Default row 1: keyboard toggle, function keys, nav block top. */
         val DEFAULT_ROW1 = listOf(
-            SNIPPETS, KEYBOARD, ATTACH, ESC_KEY, TAB_KEY, PASTE, SYM_SLASH, HOME, ARROW_UP, END, PGUP,
+            SNIPPETS, KEYBOARD, ATTACH, ESC_KEY, TAB_KEY, PASTE, TEXT_INPUT, SYM_SLASH, HOME, ARROW_UP, END, PGUP,
         )
 
         /** Default row 2: modifiers, nav block bottom, symbols. The

--- a/core/toolbar/src/main/kotlin/sh/haven/core/toolbar/KeyboardToolbar.kt
+++ b/core/toolbar/src/main/kotlin/sh/haven/core/toolbar/KeyboardToolbar.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.DesktopWindows
+import androidx.compose.material.icons.filled.EditNote
 import androidx.compose.material.icons.filled.FirstPage
 import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material.icons.filled.LastPage
@@ -194,6 +195,12 @@ data class ToolbarCallbacks(
      * reference (path or share URL) at the cursor.
      */
     val onAttachTap: () -> Unit = {},
+    /**
+     * Tap on the floating text-input key. Opens the draggable/resizable
+     * text-entry dialog over the terminal so a full line can be composed
+     * with the normal IME and sent to the session in one shot.
+     */
+    val onOpenTextInput: () -> Unit = {},
 )
 
 val LocalToolbarCallbacks = compositionLocalOf<ToolbarCallbacks> {
@@ -254,6 +261,7 @@ fun KeyboardToolbar(
     composeModeActive: Boolean = false,
     onToggleComposeMode: () -> Unit = {},
     onAttachTap: () -> Unit = {},
+    onOpenTextInput: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var shiftActive by remember { mutableStateOf(false) }
@@ -327,6 +335,7 @@ fun KeyboardToolbar(
             onSnippetLibraryChanged(newLibrary)
         },
         onAttachTap = onAttachTap,
+        onOpenTextInput = onOpenTextInput,
     )
 
     CompositionLocalProvider(
@@ -1054,6 +1063,11 @@ private fun BuiltInKey(
             description = stringResource(R.string.toolbar_attach_desc),
             onClick = cb.onAttachTap,
         )
+        ToolbarKey.TEXT_INPUT -> ToolbarIconButton(
+            icon = Icons.Filled.EditNote,
+            description = stringResource(R.string.toolbar_text_input_desc),
+            onClick = cb.onOpenTextInput,
+        )
         ToolbarKey.SHIFT -> ToolbarToggleButton("Shift", shiftActive, onClick = cb.onToggleShift)
         ToolbarKey.CTRL -> ToolbarToggleButton("Ctrl", ctrlActive, onClick = cb.onToggleCtrl)
         ToolbarKey.ALT -> ToolbarToggleButton("Alt", altActive, onClick = cb.onToggleAlt)
@@ -1262,6 +1276,7 @@ private fun ToolbarKeyIcon(icon: ImageVector, contentDescription: String? = null
 private fun keyIcon(key: ToolbarKey): ImageVector? = when (key) {
     ToolbarKey.KEYBOARD -> Icons.Filled.Keyboard
     ToolbarKey.ATTACH -> Icons.Filled.AttachFile
+    ToolbarKey.TEXT_INPUT -> Icons.Filled.EditNote
     ToolbarKey.VOICE_KEYBOARD -> Icons.Filled.Lock
     ToolbarKey.HOME -> Icons.Filled.FirstPage
     ToolbarKey.END -> Icons.Filled.LastPage
@@ -1288,6 +1303,7 @@ private fun toolbarKeyVisual(item: ToolbarItem): KeyVisual = when (item) {
     is ToolbarItem.BuiltIn -> when (item.key) {
         ToolbarKey.KEYBOARD -> KeyVisual.IconV(Icons.Filled.Keyboard, null)
         ToolbarKey.ATTACH -> KeyVisual.IconV(Icons.Filled.AttachFile, null)
+        ToolbarKey.TEXT_INPUT -> KeyVisual.IconV(Icons.Filled.EditNote, null)
         ToolbarKey.VOICE_KEYBOARD -> KeyVisual.IconV(Icons.Filled.Lock, null)
         ToolbarKey.COMPOSE -> KeyVisual.TextV("中", glyph = true)
         ToolbarKey.HOME -> KeyVisual.IconV(Icons.Filled.FirstPage, "Home")

--- a/core/toolbar/src/main/res/values/strings.xml
+++ b/core/toolbar/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="toolbar_keyboard_standard_desc">Standard keyboard (voice, suggestions, autocorrect on)</string>
     <string name="toolbar_keyboard_secure_desc">Secure keyboard (no suggestions, no autocorrect)</string>
     <string name="toolbar_attach_desc">Attach file to send to remote</string>
+    <string name="toolbar_text_input_desc">Open floating text input</string>
     <string name="toolbar_presets_label">Presets</string>
     <string name="toolbar_custom_key_label_placeholder">e.g. ^C, Paste</string>
 </resources>

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -5800,6 +5800,13 @@
      }
     },
     {
+     "name": "toolbar_text_input_desc",
+     "en": "Open floating text input",
+     "comment": "Strings added for issue #210 localisation",
+     "args": [],
+     "t": {}
+    },
+    {
      "name": "toolbar_presets_label",
      "en": "Presets",
      "comment": "Strings added for issue #210 localisation",
@@ -37238,6 +37245,76 @@
       "ru": "Нет доступного приложения камеры",
       "zh": "无可用相机应用"
      }
+    },
+    {
+     "name": "terminal_text_input_title",
+     "en": "Text input",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_placeholder",
+     "en": "Type text to send…",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_send",
+     "en": "Send",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_resize_handle",
+     "en": "Resize text input window",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_move_up",
+     "en": "Move up",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_move_down",
+     "en": "Move down",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_move_left",
+     "en": "Move left",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_move_right",
+     "en": "Move right",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_expand",
+     "en": "Make larger",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_text_input_shrink",
+     "en": "Make smaller",
+     "comment": "FloatingTextInputDialog — floating text-entry key on the keyboard toolbar. Base locale only; other locales are translation debt for the normal i18n process (do not hand-translate here).",
+     "args": [],
+     "t": {}
     },
     {
      "name": "terminal_selection_copy",

--- a/docs/plans/floating-text-input.md
+++ b/docs/plans/floating-text-input.md
@@ -1,0 +1,302 @@
+# Floating text-input dialog for terminal
+
+Status: planning — red-team reviewed 2026-07-22 (4 independent Fable-5 passes:
+gesture/UX conflict, architecture-integration correctness, multi-tab/state
+risk, completeness/testing gaps). Corrections below are resolved decisions,
+not open questions, unless marked otherwise. Target: next minor after this
+revision is accepted.
+
+## Corrections from red-team review (2026-07-22)
+
+1. **Send path must go through bracket-paste-aware injection, not raw
+   `sendInput`.** Two independent passes flagged this. Haven's existing
+   paste path checks `bracketPasteMode`/mode 2004 and wraps in
+   `ESC[200~…ESC[201~` before calling `sendInput` (see
+   `TerminalScreen.kt` `doPaste`, ~line 1117–1128, and the scan-injection
+   comment at ~line 321–335 — read the exact lines at implementation time,
+   they may drift). `sendInput` itself never wraps; callers decide. The new
+   dialog is explicitly a multi-line-capable input (the `↩`/`⇥` visual
+   transform is the point) — sending raw newlines unwrapped means every
+   embedded `\n` executes as a literal Enter in the remote session (e.g.
+   inside `vim`/`psql`), not as "paste this whole block." **Decision: reuse
+   the same bracket-wrap helper the paste path uses, do not call
+   `activeTab.sendInput` directly with unwrapped bytes.**
+
+2. **Dialog must render inside `key(activeTab.sessionId)`, and draft text
+   must be hoisted out per-tab.** The per-tab UI subtree in
+   `TerminalScreen.kt` is wrapped in `key(activeTab.sessionId) { ... }`
+   (~line 875–879, confirm exact range at implementation time). Two tabs
+   can look identical UI-wise while the *active* tab changes without a
+   user tap on the tab bar — a session dying (`syncTabs` clamps the index),
+   an MCP-driven `selectTabBySessionId`, or a delayed `selectTabByProfileId`
+   (~2s async). If the dialog is rendered **outside** that `key()` block,
+   its send closure re-binds to whatever tab is active *at send time*, not
+   the tab that was active when typing started — typed text can go to the
+   wrong session with no visible tab-switch to notice. Rendering **inside**
+   `key()` avoids this by construction (a tab-identity change tears down
+   and recreates the subtree, so a send can never outlive its own tab) at
+   the cost of losing an in-progress, unsent draft on tab switch. Decision:
+   accept that trade — safety over convenience for a feature whose whole
+   purpose is precise text delivery. Mitigate the convenience loss by NOT
+   storing draft text in local Compose `remember` inside the dialog itself;
+   instead keep an in-memory `Map<sessionId, String>` of drafts one level up
+   (e.g. in the screen's own state or a small holder), so switching back to
+   a tab restores what was typed there, even though the dialog instance
+   itself was torn down and recreated.
+
+3. **Toolbar integration must go through the `ToolbarKey` system, not a
+   bare callback + hardcoded button.** Confirmed (not just "check in
+   review" as originally written): the toolbar is data-driven off
+   `enum class ToolbarKey`, rendered through `ToolbarItem.BuiltIn(key)`
+   layouts and `when (key)` branches, and the settings editor iterates
+   `ToolbarKey.entries` for the user-facing reorder/configure UI. A bare
+   `IconButton` bypasses reorder mode, uniform-grid layout, and the
+   settings editor entirely — inconsistent with how every other toolbar
+   action in this app works. Concrete touch points (verify exact file/line
+   at implementation time, this is from a point-in-time read): new
+   `ToolbarKey` entry, a `KeyVisual`/icon mapping, a `when(key)` render
+   branch in `KeyboardToolbar.kt`, a new `ToolbarCallbacks` field
+   (mirroring `onAttachTap`), and confirming the settings-editor listing
+   picks it up automatically via `ToolbarKey.entries` (it should, if the
+   enum entry is added correctly — verify, don't assume).
+
+4. **Restore focus to the terminal on dismiss.** Plan previously wrote
+   `onDismiss = { showTextInputDialog = false }`. Add the terminal's own
+   focus requester call on dismiss (upstream's ConsoleScreen does this;
+   find Haven's equivalent terminal `FocusRequester` in `TerminalScreen.kt`
+   and call `.requestFocus()` in the dismiss lambda, not just flip the
+   boolean).
+
+5. **License attribution must be file-level, not just the existing
+   README dependency-table row.** Haven's own `LICENSE` is AGPL-3.0; the
+   README's "ConnectBot termlib | Apache-2.0" row is a *dependency* credit
+   for the separate termlib submodule, not blanket coverage for copying
+   application-layer UI source out of the same upstream project. Apache-2.0
+   §4 requires retaining attribution in copied source. House precedent
+   exists for exactly this (an existing `.kt` file in this repo carries a
+   "Ported from &lt;project&gt; (&lt;license&gt;)…" comment; there is also a
+   NOTICE-style doc for asset attribution elsewhere in the repo — find and
+   match that pattern, don't invent a new one). Add: (a) an Apache-2.0
+   license header block at the top of the new file (matching upstream's),
+   (b) a short "Ported from org.connectbot.ui.components.FloatingTextInputDialog
+   (Apache-2.0)" comment, (c) keep the existing README dependency-table row
+   as-is (it's still correct, just not sufficient alone).
+
+6. **Use `rememberSaveable`, not `remember`, for in-progress draft text**
+   (in whatever form the per-tab draft map from item 2 takes) — plain
+   `remember` loses unsent typed text across rotation or process death from
+   backgrounding. This holds user-authored content, unlike the
+   `attachSheetVisible` boolean flag it was templated from (losing a
+   dialog-open boolean is harmless; losing typed text is not).
+
+7. **Add a CHANGELOG.md entry before shipping.** Confirmed CI-enforced
+   (`scripts/check-changelog.sh`) — a release cannot ship without its
+   section. Add this to whatever step actually ships the feature, not
+   just to this plan.
+
+8. **Accessibility: decide explicitly, don't leave silent.** The
+   move/resize interactions are raw `pointerInput { detectDragGestures }`
+   drags with no `semantics { customActions }` — invisible to TalkBack.
+   Haven has shipped explicit TalkBack work for the terminal before
+   (gesture accessibility descriptions in a recent release), so this
+   project visibly cares about this class of gap. Minimum bar: either add
+   semantic custom actions for move/resize, or explicitly document in the
+   PR description that position is fixed (not TalkBack-adjustable) as a
+   known, accepted limitation — do not ship silently unaddressed.
+
+### Noted but deferred to implementation-time judgment (not blocking)
+
+- The dialog's containing `Popup` covers the full screen while open
+  (matches upstream), which means terminal scroll/selection/mouse-SGR
+  reporting AND Haven's own swipe-to-switch-tab gesture are all
+  unavailable while the dialog is open (no double-dispatch risk — Compose
+  `Popup` is a genuinely separate window — but a real "everything else is
+  frozen" UX trade while it's up). Decide at implementation time whether
+  to keep full-screen modal (simplest, matches upstream) or size the popup
+  window to its own content instead of `fillMaxSize` so a tap outside its
+  bounds can still reach the terminal.
+- Haven already has at least two related-but-different mechanisms for
+  "phone keyboard vs. terminal" friction (a `COMPOSE` IME-composition
+  toolbar mode and a `VOICE_KEYBOARD` mode). Worth one sentence in the
+  eventual PR description on why this is additive rather than overlapping,
+  but not a blocker.
+- Rotation/split-screen: the screen-fraction position/size persistence
+  (inherited from upstream) can go stale across a resize without full
+  Activity recreation; this is a pre-existing upstream gap, not introduced
+  by the port. Fine to inherit as-is unless it proves annoying in testing.
+- Existing snippet-library injection path uses a similar send mechanism —
+  worth a byte-level parity check during testing, not a design change.
+
+## Goal
+
+Port ConnectBot's "Text Input" floating dialog into Haven's terminal screen.
+Lets the user type a full command/line into a normal Compose `TextField`
+(full IME: autocorrect, cursor movement, voice input, swipe typing) instead
+of fighting the raw terminal cell for text entry, then send the whole
+string to the active session in one shot.
+
+## Why
+
+Typing directly onto the terminal surface on a phone software keyboard is
+error-prone: the keyboard's autocorrect/predictive layer and the terminal's
+own key-dispatch path interact badly, cursor/backspace behavior over an
+already-rendered terminal cell is confusing, and there is no way to review
+what you typed before it goes out keystroke-by-keystroke. Batin hit this
+directly on `nec` (screenshot, 2026-07-22) and asked for ConnectBot's
+existing "Text Input" feature, which solves exactly this by decoupling
+"where you type" (a normal text box) from "where it's displayed" (the
+terminal).
+
+## Source
+
+`org.connectbot.ui.components.FloatingTextInputDialog` in
+[connectbot/connectbot](https://github.com/connectbot/connectbot)
+(`app/src/main/java/org/connectbot/ui/components/FloatingTextInputDialog.kt`),
+Apache-2.0 — same license as Haven's existing `termlib` dependency from the
+same upstream, already credited in `README.md`. Confirmed present in the
+current upstream tree (not from an older/incompatible architecture): it is
+a Jetpack Compose `@Composable`, same UI framework Haven uses throughout
+(`feature/terminal/.../TerminalScreen.kt` is Compose-based too).
+
+Upstream shape (as read from source, not guessed):
+
+- Draggable + resizable `Popup` positioned/sized from `SharedPreferences`
+  (`floating_input_x/y/width/height`, stored as screen-fraction floats).
+- One Compose `TextField` with a `VisualTransformation` that shows `↩` for
+  embedded newlines and `⇥` for tabs inline while keeping the real
+  characters in the underlying string.
+- Header row: title + close (`X`) button, draggable to reposition.
+- Footer/side: send button (paper-plane icon) and a resize handle
+  (`OpenInFull` icon), both via `pointerInput { detectDragGestures { ... } }`.
+- Send path: `bridge.injectString(text)` then clear the field. Field is
+  **not** auto-cleared on dismiss without sending (only `X`/outside-tap
+  dismisses without send).
+
+## Integration point in Haven (found by reading the code, not assumed)
+
+Haven's per-tab session object already exposes the exact primitive needed:
+
+```kotlin
+activeTab.sendInput(bytes: ByteArray)
+```
+
+used today for paste (`TerminalScreen.kt`, both the main toolbar and the
+selection-toolbar paste path):
+
+```kotlin
+onPaste = { text -> activeTab.sendInput(text.toByteArray()) },
+```
+
+So the port is `bridge.injectString(text)` → `activeTab.sendInput(text.toByteArray())`,
+not a new session-write path.
+
+`KeyboardToolbar` (`core/toolbar/.../KeyboardToolbar.kt`) already follows a
+plain callback-param pattern for toolbar actions, e.g.:
+
+```kotlin
+val onAttachTap: () -> Unit = {}
+```
+
+The new trigger button follows the same shape: `onOpenTextInput: () -> Unit = {}`,
+wired from `TerminalScreen.kt` to flip a `showTextInputDialog` state flag,
+same pattern as the existing `attachSheetVisible` flag for the attach sheet.
+
+## Plan
+
+1. **New file** `feature/terminal/.../FloatingTextInputDialog.kt` (package
+   `sh.haven.feature.terminal`, not a straight file copy into
+   `org.connectbot.*` — Haven has already re-namespaced its own code).
+   Port the Composable body as-is; only the send call changes
+   (`activeTab.sendInput(text.toByteArray())`). Reuse Haven's own
+   `MaterialTheme` color roles already in use elsewhere in this file so it
+   matches Haven's theme, not ConnectBot's.
+2. **String resources**: add Haven-side keys (do not assume upstream's
+   exact resource names carry over; Haven's `R.string.*` catalog is its
+   own). Needs: dialog title, placeholder/label, close/send content
+   descriptions, resize-handle content description. Add to the base
+   `strings.xml`; do **not** hand-translate into every locale Haven ships —
+   flag as a translation-debt item for whatever process currently handles
+   Haven's i18n (fastlane/metadata shows many locales already tracked).
+3. **Toolbar wiring**: add `onOpenTextInput: () -> Unit = {}` to
+   `KeyboardToolbar`'s param list (mirroring `onAttachTap`), add one
+   `IconButton`/`KeyCell` entry, decide **exact placement** in review (a
+   free slot, or behind the existing toolbar's overflow/settings path —
+   `TerminalScreen.kt` already treats the toolbar as configurable
+   `toolbarLayout`/`uniformGrid`, so this may need a `ToolbarKey`-style
+   entry rather than a bare hardcoded button — check `ToolbarKey` enum
+   before assuming a raw button is idiomatic here).
+4. **State**: `var showTextInputDialog by remember { mutableStateOf(false) }`
+   in `TerminalScreen.kt`, same shape as `attachSheetVisible`; render
+   `FloatingTextInputDialog(activeTab, onDismiss = { showTextInputDialog = false })`
+   conditionally, same conditional-render pattern already used for the
+   attach sheet / VNC dialog in this file.
+5. **Persistence keys**: upstream uses bare `SharedPreferences` keys
+   (`floating_input_x` etc.) with no per-profile/per-tab scoping — confirm
+   in review whether Haven wants this shared across all tabs/profiles
+   (upstream behavior) or scoped, since Haven supports multiple concurrent
+   tabs/sessions unlike a single-session assumption this key naming might
+   imply.
+
+## Open questions for review (not decided here)
+
+- Does the floating window's own `pointerInput { detectDragGestures }`
+  (drag-to-move, drag-to-resize) fight with `TerminalScreen.kt`'s existing
+  gesture stack (`combinedClickable`, mouse SGR reporting, text selection
+  drag, scroll) when the dialog is shown as an overlay `Popup` on the same
+  screen? Upstream renders it as a `Popup(properties = PopupProperties(focusable = true))`
+  — need to confirm Compose `Popup` truly isolates its own pointer input
+  from the composables underneath, not just visually.
+- Toolbar placement: is there a free `ToolbarKey` slot, or does adding one
+  require a settings-visible toggle (Haven's toolbar is already
+  user-configurable per `toolbarLayout`/`uniformGrid`/`editModeControlsPlacement`)?
+- Multi-tab semantics: should the dialog be tied to `activeTab` only (text
+  vanishes if the user switches tabs mid-type), or should in-progress text
+  survive a tab switch?
+- i18n debt: how many locales realistically need the new strings before
+  ship vs. after (Haven tracks translations in `fastlane/metadata/android/<locale>`
+  for store listings; in-app `strings.xml` locale coverage is separate and
+  wasn't audited here).
+
+## Testing before ship
+
+- Real device (not just `./gradlew assembleDebug` succeeding): open the
+  dialog over a live SSH/mosh/local session, type text with autocorrect
+  on, send, confirm exact bytes land in the session, correctly bracket-
+  wrapped when the remote app has bracketed-paste mode on (test explicitly
+  inside `vim`/`psql`: an embedded newline must not execute as Enter).
+- Confirm existing terminal gestures (scroll, tap-to-position-cursor,
+  text selection, mouse reporting on apps like `less`/`vim`) still work
+  normally with the dialog closed, and that opening/closing the dialog
+  doesn't leave the terminal's focus/keyboard state stuck (focus must
+  return to the terminal on dismiss, not just close the dialog).
+- **Multi-tab specific (new, from red-team review):**
+  - Start typing in the dialog, switch tabs via the tab bar mid-type,
+    switch back — confirm the draft text is restored for that tab (per
+    the per-tab draft map) and confirm nothing was sent to the tab you
+    switched to.
+  - Trigger a *non-tap* active-tab change while the dialog is open (an
+    MCP-driven tab select, or let a session die so the active index
+    clamps to another tab) — confirm the dialog tears down safely (no
+    crash, no send into the wrong session) rather than silently rebinding
+    its send target.
+  - Close the tab whose dialog is open (if reachable) — confirm no crash
+    from a stale `sendInput` reference into a removed transport.
+  - Send text into a tab whose transport has since disconnected — confirm
+    this fails silently/loudly in a way consistent with how paste already
+    behaves for a dead session (don't introduce a new crash path).
+- Confirm dialog position/size persists across dialog close+reopen and
+  across app restart (matches upstream's `SharedPreferences` contract);
+  confirm draft text survives rotation (via `rememberSaveable`/hoisted
+  state) rather than being silently discarded.
+- Toolbar: confirm the new button appears correctly through the normal
+  toolbar settings/reorder editor (drag it, hide it, restore it) like any
+  other `ToolbarKey` — not just that it renders in the default layout.
+- Accessibility: with TalkBack on, confirm the documented behavior (either
+  working custom actions for move/resize, or the accepted "position fixed
+  under TalkBack" limitation) — don't ship with an undocumented silent gap.
+- Before merge: CHANGELOG.md has an entry (CI-enforced by
+  `scripts/check-changelog.sh` — a release cannot ship without it).
+- Rollback: this is a pure addition (new file + one new `ToolbarKey` entry
+  + new strings + one focus-restore call) — revert is a single commit
+  revert, no data-model or migration involved, low regression risk if
+  reverted.

--- a/feature/connections/src/main/kotlin/sh/haven/feature/connections/ConnectionsViewModel.kt
+++ b/feature/connections/src/main/kotlin/sh/haven/feature/connections/ConnectionsViewModel.kt
@@ -324,7 +324,7 @@ class ConnectionsViewModel @Inject constructor(
                     // would use this profile's stored credentials.
                     val profile = repository.getById(command.profileId)
                     if (profile != null) {
-                        _connectConfirm.value = ConnectConfirm(profile, command.sessionName)
+                        _connectConfirm.value = ConnectConfirm(profile, command.sessionName, command.startupCommand)
                     } else {
                         Log.w(TAG, "ConnectFromDeepLink: profile ${command.profileId} not found")
                     }
@@ -923,7 +923,11 @@ class ConnectionsViewModel @Inject constructor(
     // --- haven://connect deep link (#305) ---
 
     /** A matched saved profile awaiting the user's confirm before connecting. */
-    data class ConnectConfirm(val profile: ConnectionProfile, val sessionName: String?)
+    data class ConnectConfirm(
+        val profile: ConnectionProfile,
+        val sessionName: String?,
+        val startupCommand: String? = null,
+    )
 
     private val _connectConfirm = MutableStateFlow<ConnectConfirm?>(null)
     val connectConfirm: StateFlow<ConnectConfirm?> = _connectConfirm.asStateFlow()
@@ -932,7 +936,12 @@ class ConnectionsViewModel @Inject constructor(
     fun confirmDeepLinkConnect() {
         val c = _connectConfirm.value ?: return
         _connectConfirm.value = null
-        connect(c.profile, password = c.profile.sshPassword.orEmpty(), sessionName = c.sessionName)
+        connect(
+            c.profile,
+            password = c.profile.sshPassword.orEmpty(),
+            sessionName = c.sessionName,
+            startupCommand = c.startupCommand,
+        )
     }
 
     fun dismissDeepLinkConnect() {
@@ -1755,6 +1764,7 @@ class ConnectionsViewModel @Inject constructor(
         rememberPassword: Boolean? = null,
         usernameOverride: String? = null,
         sessionName: String? = null,
+        startupCommand: String? = null,
     ) {
         // Identity resolution (#360): for SSH-family profiles, substitute the
         // effective identity's username/password/key just before dialing, so
@@ -1769,11 +1779,11 @@ class ConnectionsViewModel @Inject constructor(
                 // the identity's (mirrors the jump-host merge idiom).
                 val effectivePassword =
                     if (password.isEmpty()) resolved.sshPassword.orEmpty() else password
-                connectAfterIdentity(resolved, effectivePassword, keyOnly, rememberPassword, usernameOverride, sessionName)
+                connectAfterIdentity(resolved, effectivePassword, keyOnly, rememberPassword, usernameOverride, sessionName, startupCommand)
             }
             return
         }
-        connectAfterIdentity(profile, password, keyOnly, rememberPassword, usernameOverride, sessionName)
+        connectAfterIdentity(profile, password, keyOnly, rememberPassword, usernameOverride, sessionName, startupCommand)
     }
 
     /** Post-identity dispatch: USB-drive preflight, then [connectInner]. */
@@ -1784,6 +1794,7 @@ class ConnectionsViewModel @Inject constructor(
         rememberPassword: Boolean?,
         usernameOverride: String?,
         sessionName: String?,
+        startupCommand: String? = null,
     ) {
         // USB-drive bookmarks (#287): the "USB: …" connection's VM stops on
         // eject/sleep/app-restart, leaving the profile pointing at a dead
@@ -1796,12 +1807,12 @@ class ConnectionsViewModel @Inject constructor(
                     is sh.haven.core.data.repository.ConnectionPreflight.Result.Block ->
                         _error.value = result.message
                     is sh.haven.core.data.repository.ConnectionPreflight.Result.Proceed ->
-                        connectInner(result.profile, password, keyOnly, rememberPassword, usernameOverride, sessionName)
+                        connectInner(result.profile, password, keyOnly, rememberPassword, usernameOverride, sessionName, startupCommand)
                 }
             }
             return
         }
-        connectInner(profile, password, keyOnly, rememberPassword, usernameOverride, sessionName)
+        connectInner(profile, password, keyOnly, rememberPassword, usernameOverride, sessionName, startupCommand)
     }
 
     private fun connectInner(
@@ -1811,6 +1822,7 @@ class ConnectionsViewModel @Inject constructor(
         rememberPassword: Boolean? = null,
         usernameOverride: String? = null,
         sessionName: String? = null,
+        startupCommand: String? = null,
     ) {
         if (profile.isLocal) {
             connectLocal(profile)
@@ -1877,7 +1889,14 @@ class ConnectionsViewModel @Inject constructor(
             return
         }
         if (profile.isMosh) {
-            connectMosh(profile, password, keyOnly, usernameOverride = runtimeUsername)
+            connectMosh(
+                profile,
+                password,
+                keyOnly,
+                usernameOverride = runtimeUsername,
+                preselectedSessionName = sessionName,
+                startupCommand = startupCommand,
+            )
             return
         }
         connectSsh(profile, password, keyOnly, rememberPassword, usernameOverride = runtimeUsername, preselectedSessionName = sessionName)
@@ -3408,6 +3427,8 @@ class ConnectionsViewModel @Inject constructor(
         password: String,
         keyOnly: Boolean,
         usernameOverride: String? = null,
+        preselectedSessionName: String? = null,
+        startupCommand: String? = null,
     ) {
         val effectiveUsername = usernameOverride?.takeIf { it.isNotBlank() } ?: profile.username
         viewModelScope.launch {
@@ -3438,6 +3459,21 @@ class ConnectionsViewModel @Inject constructor(
 
                 // Phase 2: Resolve session manager, check for existing sessions
                 val smgr = resolveSessionManager(profile)
+
+                // Deep-link / Tin attach: skip interactive picker when session or command given.
+                if (preselectedSessionName != null || startupCommand != null) {
+                    finishMoshConnect(
+                        sessionId = sessionId,
+                        profileId = profile.id,
+                        serverHost = profile.host,
+                        client = client,
+                        manager = smgr,
+                        chosenSessionName = preselectedSessionName,
+                        verboseLogger = verboseLogger,
+                        startupCommand = startupCommand,
+                    )
+                    return@launch
+                }
 
                 val existingSessions = withContext(Dispatchers.IO) {
                     listExistingMultiplexerSessions(smgr) { client.execCommand(it) }
@@ -4101,10 +4137,13 @@ class ConnectionsViewModel @Inject constructor(
         chosenSessionName: String?,
         silent: Boolean = false,
         verboseLogger: SshVerboseLogger? = null,
+        startupCommand: String? = null,
     ) {
         val moshConnect = withContext(Dispatchers.IO) {
             val customMoshCmd = repository.getById(profileId)?.moshServerCommand?.takeIf { it.isNotBlank() }
-            val moshCmd = customMoshCmd ?: "mosh-server new -s -c 256 -l LANG=en_US.UTF-8"
+            val baseMoshCmd = customMoshCmd ?: "mosh-server new -s -c 256 -l LANG=en_US.UTF-8"
+            // Tin/ATP clean attach: mosh-server execs COMMAND instead of $SHELL — no nested tmux orphan.
+            val moshCmd = if (!startupCommand.isNullOrBlank()) "$baseMoshCmd -- $startupCommand" else baseMoshCmd
             Log.d(TAG, "Running mosh-server bootstrap: $moshCmd")
             val result = client.execCommand(moshCmd)
 
@@ -4146,10 +4185,11 @@ class ConnectionsViewModel @Inject constructor(
         val (serverIp, moshPort, moshKey) = moshConnect
         Log.d(TAG, "MOSH CONNECT parsed: $serverIp:$moshPort")
 
-        // Build session manager command with chosen or default session name
+        // Build session manager command with chosen or default session name.
+        // When startupCommand was passed to mosh-server via `--`, do NOT also inject keystrokes.
         val smCmd = manager.command
         var effectiveSessionName: String? = null
-        if (smCmd != null) {
+        if (startupCommand == null && smCmd != null) {
             val rawName = chosenSessionName
                 ?: moshSessionManager.sessions.value[sessionId]?.label
                 ?: sessionId.take(8)

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
@@ -1,0 +1,405 @@
+/*
+ * Ported from org.connectbot.ui.components.FloatingTextInputDialog
+ * (connectbot/connectbot, Apache-2.0) — upstream license header retained
+ * below per Apache-2.0 §4. Haven changes: re-namespaced, text/send state
+ * hoisted to the caller (per-tab drafts + bracket-paste-aware send live in
+ * TerminalScreen), Haven string resources, TalkBack custom actions for
+ * move/resize.
+ *
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2025-2026 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sh.haven.feature.terminal
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.OpenInFull
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.core.content.edit
+import kotlin.math.roundToInt
+
+private const val NEWLINE_SYMBOL = "↩"
+private const val TAB_SYMBOL = "⇥"
+
+/**
+ * Shows embedded newlines as ↩ (followed by the real line break) and tabs as ⇥
+ * inline, while the underlying string keeps the real characters — so what's
+ * sent to the terminal is exactly what was typed, but the user can *see* the
+ * control characters before sending.
+ */
+private object SpecialCharVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val original = text.text
+
+        // Build transformed string and a map from original index to transformed index
+        val transformedBuilder = StringBuilder()
+        val originalToTransformed = IntArray(original.length + 1)
+        for (i in original.indices) {
+            originalToTransformed[i] = transformedBuilder.length
+            when (original[i]) {
+                '\n' -> transformedBuilder.append("$NEWLINE_SYMBOL\n")
+                '\t' -> transformedBuilder.append(TAB_SYMBOL)
+                else -> transformedBuilder.append(original[i])
+            }
+        }
+        originalToTransformed[original.length] = transformedBuilder.length
+        val transformed = transformedBuilder.toString()
+
+        // Build reverse map from transformed index to original index
+        val transformedToOriginal = IntArray(transformed.length + 1)
+        for (i in original.indices) {
+            val tStart = originalToTransformed[i]
+            val tEnd = originalToTransformed[i + 1]
+            for (t in tStart until tEnd) {
+                transformedToOriginal[t] = i
+            }
+        }
+        transformedToOriginal[transformed.length] = original.length
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int = originalToTransformed[offset.coerceIn(0, original.length)]
+
+            override fun transformedToOriginal(offset: Int): Int = transformedToOriginal[offset.coerceIn(0, transformed.length)]
+        }
+
+        return TransformedText(AnnotatedString(transformed), offsetMapping)
+    }
+}
+
+// Position/size persistence. Same screen-fraction keys as upstream, but in a
+// dedicated prefs file (Haven has no androidx.preference default-prefs users;
+// DataStore is the app-wide store and isn't worth an async round-trip for a
+// window geometry). Shared across all tabs/profiles, matching upstream.
+private const val PREFS_NAME = "floating_text_input"
+private const val PREF_FLOATING_INPUT_X = "floating_input_x"
+private const val PREF_FLOATING_INPUT_Y = "floating_input_y"
+private const val PREF_FLOATING_INPUT_WIDTH = "floating_input_width"
+private const val PREF_FLOATING_INPUT_HEIGHT = "floating_input_height"
+private const val DEFAULT_X_RATIO = 0.05f
+private const val DEFAULT_Y_RATIO = 0.3f
+private const val DEFAULT_WIDTH_RATIO = 0.9f
+private const val DEFAULT_HEIGHT_RATIO = 0.25f
+private const val MIN_WIDTH_DP = 200f
+private const val MIN_HEIGHT_DP = 80f
+
+/** Screen-fraction step used by the TalkBack custom move/resize actions. */
+private const val A11Y_STEP_RATIO = 0.1f
+
+/**
+ * Floating, draggable, resizable text-entry window over the terminal: type a
+ * full command/line with the normal IME (autocorrect, swipe typing, voice
+ * input, cursor movement), review it, then send the whole string to the
+ * session in one shot instead of fighting the raw terminal cell.
+ *
+ * State is intentionally hoisted: [text] / [onTextChange] are backed by a
+ * per-tab draft map in TerminalScreen (so an unsent draft survives tab
+ * switches, rotation and process death), and [onSend] owns the
+ * bracket-paste-aware injection into the active tab. This composable only
+ * renders and reports.
+ *
+ * @param onSend fired on the send button; the caller sends the current [text]
+ *   (bracket-wrapped as needed) and clears the draft.
+ * @param onDismiss fired on the close button, back press or a tap outside the
+ *   window. The draft is NOT cleared on dismiss — only a successful send
+ *   clears it.
+ */
+@Composable
+internal fun FloatingTextInputDialog(
+    text: String,
+    onTextChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE) }
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+
+    // Calculate screen dimensions
+    val screenWidthPx = with(density) { configuration.screenWidthDp.dp.toPx() }
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val minWidthPx = with(density) { MIN_WIDTH_DP.dp.toPx() }
+    val minHeightPx = with(density) { MIN_HEIGHT_DP.dp.toPx() }
+
+    // Load saved position/size or use defaults
+    val savedX = prefs.getFloat(PREF_FLOATING_INPUT_X, DEFAULT_X_RATIO)
+    val savedY = prefs.getFloat(PREF_FLOATING_INPUT_Y, DEFAULT_Y_RATIO)
+    val savedWidth = prefs.getFloat(PREF_FLOATING_INPUT_WIDTH, DEFAULT_WIDTH_RATIO)
+    val savedHeight = prefs.getFloat(PREF_FLOATING_INPUT_HEIGHT, DEFAULT_HEIGHT_RATIO)
+
+    // Current position and size in pixels
+    var offsetX by remember { mutableFloatStateOf(screenWidthPx * savedX) }
+    var offsetY by remember { mutableFloatStateOf(screenHeightPx * savedY) }
+    var windowWidthPx by remember { mutableFloatStateOf(screenWidthPx * savedWidth) }
+    var windowHeightPx by remember { mutableFloatStateOf(screenHeightPx * savedHeight) }
+
+    val textFieldFocusRequester = remember { FocusRequester() }
+
+    // Focus the field as soon as the window opens so typing can start
+    // immediately.
+    LaunchedEffect(Unit) {
+        textFieldFocusRequester.requestFocus()
+    }
+
+    // Save position and size when dialog closes
+    DisposableEffect(Unit) {
+        onDispose {
+            prefs.edit {
+                putFloat(PREF_FLOATING_INPUT_X, offsetX / screenWidthPx)
+                putFloat(PREF_FLOATING_INPUT_Y, offsetY / screenHeightPx)
+                putFloat(PREF_FLOATING_INPUT_WIDTH, windowWidthPx / screenWidthPx)
+                putFloat(PREF_FLOATING_INPUT_HEIGHT, windowHeightPx / screenHeightPx)
+            }
+        }
+    }
+
+    fun moveBy(dx: Float, dy: Float) {
+        offsetX = (offsetX + dx).coerceIn(0f, (screenWidthPx - windowWidthPx).coerceAtLeast(0f))
+        offsetY = (offsetY + dy).coerceIn(0f, (screenHeightPx - windowHeightPx).coerceAtLeast(0f))
+    }
+
+    fun resizeBy(dw: Float, dh: Float) {
+        windowWidthPx = (windowWidthPx + dw).coerceIn(minWidthPx, screenWidthPx - offsetX)
+        windowHeightPx = (windowHeightPx + dh).coerceIn(minHeightPx, screenHeightPx - offsetY)
+    }
+
+    // TalkBack: the raw drag gestures below are invisible to accessibility
+    // services, so expose move/resize as semantic custom actions (on the
+    // title and the resize handle respectively), stepping by a fixed screen
+    // fraction per activation.
+    val moveStepX = screenWidthPx * A11Y_STEP_RATIO
+    val moveStepY = screenHeightPx * A11Y_STEP_RATIO
+    val moveActions = listOf(
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_move_up)) {
+            moveBy(0f, -moveStepY); true
+        },
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_move_down)) {
+            moveBy(0f, moveStepY); true
+        },
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_move_left)) {
+            moveBy(-moveStepX, 0f); true
+        },
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_move_right)) {
+            moveBy(moveStepX, 0f); true
+        },
+    )
+    val resizeActions = listOf(
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_expand)) {
+            resizeBy(moveStepX, moveStepY); true
+        },
+        CustomAccessibilityAction(stringResource(R.string.terminal_text_input_shrink)) {
+            resizeBy(-moveStepX, -moveStepY); true
+        },
+    )
+    val resizeHandleDescription = stringResource(R.string.terminal_text_input_resize_handle)
+
+    Popup(
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    // Tap outside the window dismisses (without clearing the
+                    // draft — it's hoisted). The full-screen scrim also
+                    // deliberately keeps terminal gestures frozen while the
+                    // dialog is up, matching upstream.
+                    detectTapGestures(onTap = { onDismiss() })
+                },
+        ) {
+            Column(
+                modifier = Modifier
+                    .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+                    .width(with(density) { windowWidthPx.toDp() })
+                    .background(
+                        MaterialTheme.colorScheme.surface,
+                        RoundedCornerShape(12.dp),
+                    ),
+            ) {
+                // Draggable header with title and close button
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(36.dp)
+                        .background(
+                            MaterialTheme.colorScheme.primary,
+                            RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
+                        )
+                        .pointerInput(Unit) {
+                            detectDragGestures { change, dragAmount ->
+                                change.consume()
+                                moveBy(dragAmount.x, dragAmount.y)
+                            }
+                        }
+                        .padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = stringResource(R.string.terminal_text_input_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier
+                            .weight(1f)
+                            .semantics { customActions = moveActions },
+                    )
+
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.size(24.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = stringResource(R.string.common_close),
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+
+                // TextField with send button and resize handle to the right
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(with(density) { (windowHeightPx - 36.dp.toPx()).coerceAtLeast(minHeightPx).toDp() }),
+                ) {
+                    TextField(
+                        value = text,
+                        onValueChange = onTextChange,
+                        placeholder = {
+                            Text(stringResource(R.string.terminal_text_input_placeholder))
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Text,
+                        ),
+                        visualTransformation = SpecialCharVisualTransformation,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                        ),
+                        shape = RoundedCornerShape(bottomStart = 12.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .focusRequester(textFieldFocusRequester),
+                    )
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .background(
+                                MaterialTheme.colorScheme.surfaceVariant,
+                                RoundedCornerShape(bottomEnd = 12.dp),
+                            ),
+                        verticalArrangement = Arrangement.SpaceBetween,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        IconButton(
+                            onClick = onSend,
+                            modifier = Modifier.size(48.dp),
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Send,
+                                contentDescription = stringResource(R.string.terminal_text_input_send),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .semantics {
+                                    contentDescription = resizeHandleDescription
+                                    customActions = resizeActions
+                                }
+                                .pointerInput(Unit) {
+                                    detectDragGestures { change, dragAmount ->
+                                        change.consume()
+                                        resizeBy(dragAmount.x, dragAmount.y)
+                                    }
+                                },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Default.OpenInFull,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -295,6 +295,20 @@ fun TerminalScreen(
     var pendingScanMode by remember { mutableStateOf<TerminalViewModel.ScanMode?>(null) }
     var cameraOutputUri by remember { mutableStateOf<Uri?>(null) }
 
+    // Floating text-input dialog (ported from ConnectBot). Both pieces of
+    // state are hoisted ABOVE the key(activeTab.sessionId) block below: the
+    // dialog itself renders *inside* key() so its send closure can never
+    // outlive its tab (a non-tap active-tab change — session death clamping
+    // the index, an MCP selectTabBySessionId — tears the dialog down instead
+    // of silently re-binding typed text to the wrong session), while the
+    // per-tab draft map up here means switching back to a tab restores what
+    // was typed there. rememberSaveable (not remember) because drafts are
+    // user-authored text that must survive rotation and process death —
+    // unlike the attachSheetVisible boolean above, losing them is not
+    // harmless. HashMap is Serializable, so the autoSaver handles it.
+    var textInputDialogVisible by rememberSaveable { mutableStateOf(false) }
+    var textInputDrafts by rememberSaveable { mutableStateOf(HashMap<String, String>()) }
+
     val cameraScanLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.TakePicture()
     ) { success ->
@@ -1119,12 +1133,9 @@ fun TerminalScreen(
                         val doPaste: () -> Unit = {
                             val text = realClipboard.getText()?.text
                             if (!text.isNullOrEmpty()) {
-                                val payload = if (isBracketPaste) {
-                                    "\u001b[200~$text\u001b[201~"
-                                } else {
-                                    text
-                                }
-                                activeTab.sendInput(payload.toByteArray())
+                                activeTab.sendInput(
+                                    bracketPasteWrap(text, isBracketPaste).toByteArray(),
+                                )
                             }
                         }
 
@@ -1331,6 +1342,7 @@ fun TerminalScreen(
                         composeModeActive = composeController?.isComposeModeActive == true,
                         onToggleComposeMode = { composeController?.toggleComposeMode() },
                         onAttachTap = { attachSheetVisible = true },
+                        onOpenTextInput = { textInputDialogVisible = true },
                         selectionContent = selectionController?.let { ctrl -> {
                             SelectionToolbarContent(
                                 controller = ctrl,
@@ -1341,6 +1353,51 @@ fun TerminalScreen(
                         } },
                         modifier = Modifier.fillMaxWidth(),
                     )
+
+                    // Floating text-input dialog — MUST stay inside the
+                    // key(activeTab.sessionId) block: an active-tab change of
+                    // any kind (tap, session death clamping the index, MCP
+                    // selectTabBySessionId) then tears it down and recreates
+                    // it, so a send can never fire into a tab other than the
+                    // one it was opened for. The draft itself lives in the
+                    // per-tab textInputDrafts map hoisted above the key()
+                    // boundary, so it survives the teardown.
+                    if (textInputDialogVisible) {
+                        FloatingTextInputDialog(
+                            text = textInputDrafts[activeTab.sessionId].orEmpty(),
+                            onTextChange = { draft ->
+                                textInputDrafts = HashMap(textInputDrafts).apply {
+                                    if (draft.isEmpty()) {
+                                        remove(activeTab.sessionId)
+                                    } else {
+                                        put(activeTab.sessionId, draft)
+                                    }
+                                }
+                            },
+                            onSend = {
+                                val draft = textInputDrafts[activeTab.sessionId].orEmpty()
+                                if (draft.isNotEmpty()) {
+                                    // Same bracket-wrap path as paste: an
+                                    // embedded newline must arrive as pasted
+                                    // text (mode 2004), not execute as a
+                                    // literal Enter inside vim/psql.
+                                    activeTab.sendInput(
+                                        bracketPasteWrap(draft, isBracketPaste).toByteArray(),
+                                    )
+                                    textInputDrafts = HashMap(textInputDrafts).apply {
+                                        remove(activeTab.sessionId)
+                                    }
+                                }
+                            },
+                            onDismiss = {
+                                textInputDialogVisible = false
+                                // Hand focus (and the IME's InputConnection)
+                                // back to the terminal, so typing resumes in
+                                // the session instead of going nowhere.
+                                focusRequester.requestFocus()
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -1459,6 +1516,17 @@ private fun handleLayoutAwareKeyEvent(
 
     return true
 }
+
+/**
+ * Wrap [text] in bracketed-paste markers (xterm mode 2004) when the remote
+ * app has requested them, so pasted/injected text — embedded newlines
+ * included — arrives as one "paste this block" event instead of being
+ * interpreted keystroke-by-keystroke. `sendInput` itself never wraps;
+ * callers decide. Shared by the paste path (doPaste / Ctrl+Shift+V) and the
+ * floating text-input dialog's send.
+ */
+internal fun bracketPasteWrap(text: CharSequence, bracketPasteMode: Boolean): String =
+    if (bracketPasteMode) "\u001b[200~$text\u001b[201~" else text.toString()
 
 /** Keys that termlib maps to VTermKey codes — let termlib handle these directly. */
 private fun isSpecialTerminalKey(keyCode: Int): Boolean {

--- a/feature/terminal/src/main/res/values/strings.xml
+++ b/feature/terminal/src/main/res/values/strings.xml
@@ -99,6 +99,20 @@
     <string name="terminal_scan_failed">Scan failed: %s</string>
     <string name="terminal_scan_no_camera">No camera app available</string>
 
+    <!-- FloatingTextInputDialog — floating text-entry key on the keyboard toolbar.
+         Base locale only; other locales are translation debt for the normal
+         i18n process (do not hand-translate here). -->
+    <string name="terminal_text_input_title">Text input</string>
+    <string name="terminal_text_input_placeholder">Type text to send…</string>
+    <string name="terminal_text_input_send">Send</string>
+    <string name="terminal_text_input_resize_handle">Resize text input window</string>
+    <string name="terminal_text_input_move_up">Move up</string>
+    <string name="terminal_text_input_move_down">Move down</string>
+    <string name="terminal_text_input_move_left">Move left</string>
+    <string name="terminal_text_input_move_right">Move right</string>
+    <string name="terminal_text_input_expand">Make larger</string>
+    <string name="terminal_text_input_shrink">Make smaller</string>
+
     <!-- SelectionToolbar button labels and toasts -->
     <string name="terminal_selection_copy">Copy</string>
     <string name="terminal_selection_paste">Paste</string>


### PR DESCRIPTION
## Summary
- Ports ConnectBot's `FloatingTextInputDialog` (Apache-2.0) into Haven's terminal feature — a
  draggable/resizable floating dialog for typing longer text and sending it to the active
  session, useful when the on-screen keyboard makes multi-line composition awkward.
- Adds a new `TEXT_INPUT` keyboard-toolbar key (reorderable like any other toolbar key) that
  opens the dialog.
- Draft text is hoisted per-tab (keyed by `sessionId`), so switching tabs mid-draft doesn't lose
  or leak text into the wrong session.
- Send path reuses the existing bracket-paste-aware `sendInput`, so multi-line text pastes
  correctly into apps like vim/psql that honor bracket-paste mode.
- Move/resize are exposed to TalkBack via `semantics { customActions = ... }`.
- Upstream license header retained in the ported file per Apache-2.0 §4; see
  `docs/plans/floating-text-input.md` for the full design writeup and the red-team review this
  went through before implementation.

## Known CI status
- `build` (debug APK) passes.
- `lint` currently fails on `MissingTranslation` for the new strings — per
  `docs/features/i18n.md` this repo's convention is new strings ship English-only and pick up
  translations via the community translate page, not hand-authored in the PR
  (`docs/i18n/strings.json` entries are intentionally left with empty `"t": {}` and say so in a
  comment). Flagging this explicitly rather than leaving the failing check unexplained — let me
  know if this project actually wants placeholder translations included in-PR instead and I'll
  adjust.

## Test plan
- [x] Built via CI (`workflow_dispatch`), installed the resulting debug APK on a real device,
      verified: toolbar key appears after enabling it in Settings → Keyboard & input → Keyboard
      toolbar (pre-existing saved toolbar layouts don't auto-gain new keys — expected, not a
      bug), dialog opens, typed text sends correctly to a live SSH session.
- [ ] Bracket-paste behavior inside vim/psql on real device (multi-line send) — not yet
      exercised beyond a single-line smoke test.
- [ ] TalkBack move/resize custom actions — not yet verified with a screen reader.