### PR TITLE
fix(terminal): text-selection toolbar missing in floating text input

### DIFF
--- a/docs/plans/floating-text-input-toolbar-fix.md
+++ b/docs/plans/floating-text-input-toolbar-fix.md
@@ -1,6 +1,63 @@
 # Plan — custom text-selection toolbar for the floating text input dialog
 
-## Context
+## ⚠️ ROUND 2 (2026-07-23) — round-1 fix FAILED real-device test, new lead found
+
+The round-1 implementation (custom `TextToolbar` via `LocalTextToolbar`, committed as
+`f420edf1` on `fix/floating-text-input-selection-toolbar`) compiled clean, passed its own unit
+tests, and was reasoned to be correct — but **Batin tested the real debug APK on his device and
+the toolbar still does not appear.** Selection still works (handles visible), still no
+Copy/Cut/Paste/Select-all menu. This is a genuine implementation failure, not a test error — do
+not re-ship round 1 as-is.
+
+**New lead, found by reading real Compose Foundation source** (`androidx/androidx` on GitHub,
+`compose/foundation/foundation/.../text/selection/TextFieldSelectionManager.kt` and
+`ComposeFoundationFlags.kt`): recent Compose Foundation has **two parallel context-menu systems**
+gated by `ComposeFoundationFlags.isNewContextMenuEnabled` (default comes from a per-platform
+`internal expect val isNewContextMenuInitiallyEnabled`, not confirmed for Android/this exact
+version via web source alone — **verify the REAL compiled default by decompiling the actual
+pinned `androidx.compose.foundation` AAR classes in this machine's Gradle cache, not by trusting
+a web search** of the source, which hit rate limits and inconclusive results this round).
+
+The doc comment on the flag: *"Whether to use the new context menu API and default
+implementations in SelectionContainer and all BasicTextFields. If false, the previous context
+menu that has no public APIs will be used instead."* `TextFieldSelectionManager.kt` branches on
+this flag for how it decides the toolbar is "shown" (`textToolbarShownViaProvider` vs
+`textToolbar?.status`), and toolbar display in the new-flag-true path appears to go through
+`textContextMenuToolbarHandler()` / `updateFloatingToolbar()` — a **different mechanism than
+`LocalTextToolbar.showMenu()`** entirely. **If this flag defaults to true for the pinned Compose
+version, round 1's entire `LocalTextToolbar` override may be a no-op**, because the real UI path
+never calls `showMenu` at all in that mode — this would fully explain the real-device failure
+without any bug in round 1's own code.
+
+**What round 2 must do, in order:**
+1. Decompile/inspect the REAL `androidx.compose.foundation:foundation` jar for the exact version
+   this repo pins (check `gradle/libs.versions.toml` → compose-bom → resolve to the exact
+   foundation artifact version, same technique round 1 used successfully for the `TextToolbar`
+   interface via `javap`) to get the actual compiled default of `isNewContextMenuInitiallyEnabled`
+   on Android for that version. Don't guess from web search.
+2. If the new system is enabled by default: find the real, current public API for customizing the
+   NEW context menu (search the same real Compose Foundation source/jar for whatever composition
+   local or provider interface the new system exposes — the AndroidX doc comment says the new
+   system "has public APIs", implying there IS a documented customization point; find its actual
+   name from the real source/jar, don't guess a name).
+3. Decide and implement one of: (a) wire the fix through the new system's real customization API
+   instead of `LocalTextToolbar`, or (b) if `ComposeFoundationFlags.isNewContextMenuEnabled` can be
+   scoped/overridden narrowly (not just a single global static toggle affecting the whole app) —
+   verify whether it's genuinely global-only or has some scoping mechanism — and only fall back to
+   forcing it off globally if there's no narrower option, flagging that as an app-wide behavior
+   change for the reviewer to weigh consciously (it would also change every OTHER text field in
+   Haven, not just this dialog — that's a real, non-trivial trade-off to surface honestly, not
+   silently take).
+4. This dialog uses Material3 `TextField`, not `BasicTextField` directly — confirm which context-
+   menu path Material3's `TextField` actually wires up to for the pinned Compose Material3
+   version too (it may not follow `BasicTextField`'s flag-gated behavior identically; verify, don't
+   assume it's the same).
+5. Still no real device available in this environment — be exactly as honest as round 1 was about
+   what's proven vs. reasoned. If genuinely impossible to verify visual rendering without a real
+   device/emulator here, say so plainly and say what the NEXT real-device test should specifically
+   check, rather than re-claiming confidence that didn't hold up last time.
+
+## Context (round 1, still accurate)
 
 Batin found (real device, 2026-07-23): highlighting/selecting text inside the floating Text
 Input dialog (`FloatingTextInputDialog.kt`) shows the selection handles fine, but the native

--- a/docs/plans/floating-text-input-toolbar-fix.md
+++ b/docs/plans/floating-text-input-toolbar-fix.md
@@ -1,0 +1,145 @@
+# Plan — custom text-selection toolbar for the floating text input dialog
+
+## Context
+
+Batin found (real device, 2026-07-23): highlighting/selecting text inside the floating Text
+Input dialog (`FloatingTextInputDialog.kt`) shows the selection handles fine, but the native
+Android floating action-mode toolbar (Copy / Cut / Paste / Select all) that normally appears
+above a text selection never shows up. Every other native text input on the device shows it
+normally — only this dialog is missing it.
+
+Root cause (verified, not guessed): the dialog renders its `TextField` inside a Compose `Popup`
+(`Popup(properties = PopupProperties(focusable = true))`, `FloatingTextInputDialog.kt` line ~263).
+This is a documented Compose limitation — a `TextField` inside a focusable `Popup` has a known
+focus-management conflict with the platform `ActionMode`/text-selection-toolbar machinery, so the
+toolbar silently never appears (no crash, no error — it just never shows). Source:
+https://github.com/JetBrains/compose-multiplatform/issues/2810 (same underlying Popup+TextField
+focus conflict, filed against Compose Multiplatform but the same root mechanism affects Compose
+on Android). Not switching to `Dialog` to fix this: the design doc
+(`docs/plans/floating-text-input.md`, already in this repo) and the maintainer's own device-test
+comment on PR #439 confirm the `Popup` was chosen deliberately (isolated pointer-input dispatch —
+verified no touch double-consumption with the terminal underneath; a `Dialog` would change that
+touch-dispatch behavior and the tap-outside-to-dismiss-without-clearing-draft behavior, which is
+already correct and tested). Fix the toolbar without changing the window type.
+
+## Ground truth read before writing this plan (don't skip re-verifying this against upstream/main
+before implementing — Haven moves fast, this repo was at v5.83.3 when this plan was written)
+
+- Current file: `feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt`
+  (405 lines on `upstream/main` as of this writing). `TextField(...)` call is the one composable
+  that needs the toolbar fix; nothing else in the file changes.
+- `git grep LocalTextToolbar` across the whole repo: **zero hits** — no existing custom
+  `TextToolbar` implementation anywhere in Haven to copy from. This is new ground, not a
+  copy-paste-from-elsewhere job.
+- Existing clipboard-access idiom already used elsewhere in this codebase (match this style, don't
+  introduce Compose's `LocalClipboardManager` instead — it isn't used anywhere else here):
+  `core/toolbar/src/main/kotlin/sh/haven/core/toolbar/KeyboardToolbar.kt` line ~271:
+  ```kotlin
+  val view = LocalView.current
+  val clipboardManager = remember {
+      view.context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+  }
+  ```
+  Use the same `LocalView.current` → platform `android.content.ClipboardManager` pattern here.
+
+## The fix
+
+Compose's public, documented escape hatch for exactly this situation is `TextToolbar` +
+`LocalTextToolbar` (`androidx.compose.ui.platform.TextToolbar`, `LocalTextToolbar` composition
+local) — verified against the real API reference:
+https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/TextToolbar . A custom
+`TextToolbar` implementation gets exactly 4 fixed callback slots — `onCopyRequested`,
+`onCutRequested`, `onPasteRequested`, `onSelectAllRequested` — the API does not support adding
+extra menu items, which is fine here since those 4 are exactly what's missing.
+
+**Verify the exact `TextToolbar` interface shape against the real installed Compose UI version
+before writing code** — check `androidx.compose.ui:ui` version pinned in
+`gradle/libs.versions.toml` and read the actual decompiled/sources-jar interface (`showMenu`,
+`hide`, `status` members) rather than assuming from memory; the interface has changed slightly
+across Compose versions in the past (parameter types on `showMenu`, e.g. `Rect` vs `Offset`-based
+overloads).
+
+Implementation shape (adjust exact signatures to whatever the verified real interface requires):
+
+```kotlin
+private class DialogTextToolbar(
+    private val view: View,
+    private val clipboardManager: ClipboardManager?,
+) : TextToolbar {
+    override var status: TextToolbarStatus = TextToolbarStatus.Hidden
+        private set
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?,
+    ) {
+        // Build a small Compose-based floating menu (a Popup positioned at `rect`,
+        // OR — simpler and known to sidestep the same Popup-in-Popup focus issue —
+        // a plain Android PopupWindow anchored via `view`) with up to 4 buttons,
+        // calling straight through to the passed callbacks. Verify which approach
+        // actually renders/dismisses correctly inside the outer floating-text-input
+        // Popup before committing to one — this is the one part of the plan that's
+        // a genuine implementation risk, not a known-good recipe. Test on a real
+        // device/emulator, not just "it compiles".
+        status = TextToolbarStatus.Shown
+    }
+
+    override fun hide() {
+        status = TextToolbarStatus.Hidden
+    }
+}
+```
+
+Wire it in `FloatingTextInputDialog.kt` around just the `TextField`:
+
+```kotlin
+val view = LocalView.current
+val clipboardManager = remember {
+    view.context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+}
+val customToolbar = remember(view, clipboardManager) { DialogTextToolbar(view, clipboardManager) }
+
+CompositionLocalProvider(LocalTextToolbar provides customToolbar) {
+    TextField(
+        value = text,
+        onValueChange = onTextChange,
+        // ...unchanged...
+    )
+}
+```
+
+`onCopyRequested`/`onCutRequested`/`onPasteRequested`/`onSelectAllRequested` operate on the
+`TextFieldValue`'s current selection (`text`/`onTextChange` are already hoisted to the caller per
+the existing design — the toolbar callbacks read/write through those, they don't need their own
+state) plus `clipboardManager.setPrimaryClip(...)`/`getPrimaryClip()` for the actual clipboard I/O,
+matching the existing `KeyboardToolbar.kt` idiom.
+
+## What to verify before calling this done
+
+1. Real device or emulator test (not just compile): open the dialog, type multi-word text, select
+   a range by drag, confirm the Copy/Cut/Paste/Select-all toolbar now appears and each button
+   actually works (copy → paste back in, cut removes + clipboard has it, select-all selects
+   everything).
+2. Confirm the toolbar's own popup/menu doesn't visually break or get clipped by the outer
+   floating-text-input window's bounds — this is the actual open implementation risk flagged
+   above, verify it doesn't recreate a NEW version of the same Popup-focus problem one level down.
+3. Confirm existing behavior is unchanged: bracket-paste send path, drag-to-move, resize, TalkBack
+   custom actions (move/resize) — this fix should touch nothing except the selection toolbar.
+4. Re-run whatever this module's existing Compose UI tests are (check for a
+   `FloatingTextInputDialogTest.kt` or similar under `feature/terminal/src/test` /
+   `src/androidTest` — verify it exists and what it currently covers before assuming there's
+   nothing to run).
+
+## What NOT to do
+
+- Do not switch `Popup` to `Dialog` to sidestep the issue — changes touch-dispatch behavior that's
+  deliberate and already tested (see Context section above).
+- Do not touch any file other than `FloatingTextInputDialog.kt` (and a new test file if one is
+  warranted) — this is a scoped, single-file fix.
+- Do not guess the `TextToolbar` interface shape from a general Compose blog post — verify against
+  the actual pinned Compose UI version's real interface first.
+- Do not commit/push — leave changes as an uncommitted diff on a fresh branch cut from
+  `upstream/main` for review before anything ships.

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
@@ -44,6 +44,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItem
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuSeparator
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuSession
+import androidx.compose.foundation.text.contextmenu.provider.LocalTextContextMenuDropdownProvider
+import androidx.compose.foundation.text.contextmenu.provider.LocalTextContextMenuToolbarProvider
+import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuDataProvider
+import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuProvider
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
@@ -56,6 +63,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -73,6 +81,8 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -94,7 +104,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.core.content.edit
+import kotlin.coroutines.resume
 import kotlin.math.roundToInt
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 private const val NEWLINE_SYMBOL = "↩"
 private const val TAB_SYMBOL = "⇥"
@@ -183,25 +195,34 @@ internal class TextSelectionMenuRequest(
 )
 
 /**
- * Replacement for Compose's default ActionMode-backed text toolbar, needed
- * because this dialog's TextField lives inside a focusable [Popup]: a popup
- * window has no real DecorView, so `View.startActionMode(TYPE_FLOATING)` —
- * which the default `AndroidTextToolbar` relies on — silently does nothing
- * there, and the Copy/Cut/Paste/Select-all toolbar never appears (no crash,
- * no log; see docs/plans/floating-text-input-toolbar-fix.md). Provided via
- * `LocalTextToolbar` scoped to just the TextField.
+ * Replacement for Compose's OLD (pre-flag) ActionMode-backed text toolbar,
+ * provided via `LocalTextToolbar` scoped to just the TextField.
+ *
+ * ⚠️ On the Compose version this app pins (foundation 1.11.4 via compose-bom
+ * 2026.06.01) this class is normally DORMANT: the compiled default of
+ * `ComposeFoundationFlags.isNewContextMenuEnabled` is `true` (verified by
+ * disassembling the real foundation-android 1.11.4 AAR — the static
+ * initializer stores `iconst_1` into that field), and when that flag is true
+ * the text-selection machinery never calls `TextToolbar.showMenu` at all; it
+ * goes through the new `TextContextMenuProvider` system instead (see
+ * [FloatingInputTextContextMenuProvider], which is the fix that actually
+ * fires on this version). This is exactly why round 1 of this fix — which
+ * consisted only of this class — compiled clean, passed its tests, and still
+ * did nothing on a real device. Kept because it is cheap, already tested,
+ * and becomes the active path if the flag is ever false (older/newer Compose
+ * versions, or the app/a library flipping the global flag).
  *
  * This class only *captures* the show/hide requests as snapshot state; the
  * menu itself is rendered by [TextSelectionMenu] inside the popup's own
  * window — deliberately NOT another Popup window, so there is no second
- * focusable window to recreate the same focus conflict one level down.
+ * focusable window to recreate the platform ActionMode's focus conflict
+ * (a popup window has no real DecorView, so `startActionMode(TYPE_FLOATING)`
+ * silently no-ops there) one level down.
  *
- * Signature verified against androidx.compose.ui:ui 1.11.4 (the version the
- * pinned compose-bom 2026.06.01 resolves to): the abstract `showMenu` takes
- * (rect, onCopy, onPaste, onCut, onSelectAll), all callbacks nullable; the
- * 5-callback `onAutofillRequested` overload is an interface default that
- * delegates here, so it needs no override (this menu offers no Autofill
- * entry, matching the pre-fix behavior of this dialog).
+ * Signature verified against androidx.compose.ui:ui 1.11.4: the abstract
+ * `showMenu` takes (rect, onCopy, onPaste, onCut, onSelectAll), all callbacks
+ * nullable; the 5-callback `onAutofillRequested` overload is an interface
+ * default that delegates here, so it needs no override.
  */
 internal class FloatingInputTextToolbar : TextToolbar {
     var menuRequest by mutableStateOf<TextSelectionMenuRequest?>(null)
@@ -228,6 +249,79 @@ internal class FloatingInputTextToolbar : TextToolbar {
 
     override fun hide() {
         menuRequest = null
+    }
+}
+
+/**
+ * One active menu request from the NEW context-menu system: the [session]
+ * (closing it tells the text field the menu was dismissed/acted on) and the
+ * [dataProvider] (which yields the menu items and the selection bounds).
+ *
+ * Internal (not private) so unit tests can drive
+ * [FloatingInputTextContextMenuProvider] directly.
+ */
+internal class FloatingInputContextMenuRequest(
+    val session: TextContextMenuSession,
+    val dataProvider: TextContextMenuDataProvider,
+)
+
+/**
+ * The fix that actually fires on the pinned Compose version. Foundation
+ * 1.11.4 ships `ComposeFoundationFlags.isNewContextMenuEnabled = true`
+ * (verified against the real AAR bytecode, not the docs), which switches
+ * every text field — including Material3's `TextField`, whose
+ * String+VisualTransformation overload delegates to the legacy
+ * `CoreTextField` (verified: M3 1.4.0 `TextFieldKt$TextField$1` →
+ * `BasicTextField` → `CoreTextField` → `CommonContextMenuArea`, and M3 has
+ * zero context-menu wiring of its own) — onto the NEW context-menu pipeline:
+ *
+ *   `TextFieldSelectionManager` → `ToolbarRequester.show()` →
+ *   `Modifier.textContextMenuToolbarHandler` node →
+ *   `LocalTextContextMenuToolbarProvider.current.showTextContextMenu(...)`
+ *
+ * The platform default provider for that local
+ * (`AndroidTextContextMenuToolbarProvider`) is ActionMode-based — the same
+ * mechanism that silently no-ops inside this dialog's focusable [Popup] —
+ * which is why the toolbar never appeared. This class replaces it with an
+ * in-window implementation: [showTextContextMenu] just parks the request in
+ * snapshot state and suspends until the session is closed or the selection
+ * machinery cancels the call; [TextContextMenuOverlay] renders the menu as a
+ * sibling inside the SAME popup window (no ActionMode, no second window).
+ *
+ * The menu items themselves (Cut/Copy/Paste/Select-all, localized labels,
+ * only-currently-applicable ones) are built and contributed by the text
+ * field itself (`addBasicTextFieldTextContextMenuComponents`, applied by
+ * `CoreTextField` when the flag is true) and arrive via
+ * [TextContextMenuDataProvider.data] — this provider adds none of its own.
+ *
+ * MUST be provided for BOTH [LocalTextContextMenuToolbarProvider] and
+ * [LocalTextContextMenuDropdownProvider]: the field's internal
+ * `ProvideDefaultPlatformTextContextMenuProviders` wrapper re-provides the
+ * platform defaults for BOTH locals (shadowing ours) unless BOTH are already
+ * non-null at the field (verified in the 1.11.4 bytecode — the passthrough
+ * branch requires `dropdown != null && toolbar != null`).
+ */
+internal class FloatingInputTextContextMenuProvider : TextContextMenuProvider {
+    var request by mutableStateOf<FloatingInputContextMenuRequest?>(null)
+        private set
+
+    override suspend fun showTextContextMenu(dataProvider: TextContextMenuDataProvider) {
+        var myRequest: FloatingInputContextMenuRequest? = null
+        try {
+            suspendCancellableCoroutine { continuation ->
+                val session = object : TextContextMenuSession {
+                    override fun close() {
+                        if (continuation.isActive) continuation.resume(Unit)
+                    }
+                }
+                myRequest = FloatingInputContextMenuRequest(session, dataProvider)
+                request = myRequest
+            }
+        } finally {
+            // Only clear if a newer concurrent showTextContextMenu call
+            // hasn't already replaced the request with its own.
+            if (request === myRequest) request = null
+        }
     }
 }
 
@@ -282,9 +376,20 @@ internal fun FloatingTextInputDialog(
     val textFieldFocusRequester = remember { FocusRequester() }
 
     // Custom selection toolbar (Copy/Cut/Paste/Select all) — the platform
-    // ActionMode one never shows inside this focusable Popup; see the class
-    // docs on FloatingInputTextToolbar.
+    // ActionMode one never shows inside this focusable Popup. TWO hooks are
+    // needed because Compose Foundation has two parallel, flag-gated
+    // context-menu systems (ComposeFoundationFlags.isNewContextMenuEnabled;
+    // compiled default = true on the pinned foundation 1.11.4):
+    //  - textContextMenuProvider serves the NEW system — the one that is
+    //    actually active on this version (see its class docs);
+    //  - selectionTextToolbar serves the OLD LocalTextToolbar system, kept
+    //    as the fallback if the flag is ever false.
     val selectionTextToolbar = remember { FloatingInputTextToolbar() }
+    val textContextMenuProvider = remember { FloatingInputTextContextMenuProvider() }
+
+    // Coordinates of the popup's root content Box; the new-system menu needs
+    // them to translate the selection bounds into this window's space.
+    var popupContentCoordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
 
     // Focus the field as soon as the window opens so typing can start
     // immediately.
@@ -351,6 +456,7 @@ internal fun FloatingTextInputDialog(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .onGloballyPositioned { popupContentCoordinates = it }
                 .pointerInput(Unit) {
                     // Tap outside the window dismisses (without clearing the
                     // draft — it's hoisted). The full-screen scrim also
@@ -415,11 +521,19 @@ internal fun FloatingTextInputDialog(
                         .fillMaxWidth()
                         .height(with(density) { (windowHeightPx - 36.dp.toPx()).coerceAtLeast(minHeightPx).toDp() }),
                 ) {
-                    // LocalTextToolbar is scoped to just this TextField: the
-                    // selection machinery inside it routes its ActionMode
-                    // requests to our toolbar, while everything else in the
-                    // dialog keeps the ambient default.
-                    CompositionLocalProvider(LocalTextToolbar provides selectionTextToolbar) {
+                    // All three locals are scoped to just this TextField so
+                    // everything else in the dialog keeps the ambient
+                    // defaults. The new-system provider is deliberately set
+                    // for BOTH the toolbar AND dropdown locals: the field's
+                    // internal default-installer only respects outside
+                    // providers when both are non-null (see the provider's
+                    // class docs), and this also gives a mouse right-click
+                    // the same in-window menu.
+                    CompositionLocalProvider(
+                        LocalTextToolbar provides selectionTextToolbar,
+                        LocalTextContextMenuToolbarProvider provides textContextMenuProvider,
+                        LocalTextContextMenuDropdownProvider provides textContextMenuProvider,
+                    ) {
                         TextField(
                             value = text,
                             onValueChange = onTextChange,
@@ -497,26 +611,37 @@ internal fun FloatingTextInputDialog(
             // would reintroduce the exact focus/window problem this replaces.
             // The empty area of the overlay doesn't consume touches, so the
             // scrim's tap-outside-to-dismiss keeps working.
+            //
+            // Only one of these two can ever be non-null at a time — which
+            // one depends on ComposeFoundationFlags.isNewContextMenuEnabled
+            // (true on the pinned foundation 1.11.4 → the second one).
             selectionTextToolbar.menuRequest?.let { request ->
                 TextSelectionMenu(request = request)
+            }
+            textContextMenuProvider.request?.let { request ->
+                popupContentCoordinates?.takeIf { it.isAttached }?.let { coordinates ->
+                    TextContextMenuOverlay(
+                        request = request,
+                        destinationCoordinates = coordinates,
+                    )
+                }
             }
         }
     }
 }
 
 /**
- * The floating Copy/Cut/Paste/Select-all menu for [FloatingInputTextToolbar].
- * Positioned above the selection rect ([TextSelectionMenuRequest.rect], in
- * root coordinates — the popup content fills its window, so root == window),
- * falling back to below the rect when there is no room above, clamped to the
- * window horizontally. Button order matches the platform ActionMode toolbar
- * (Cut, Copy, Paste, Select all) and labels reuse the system's own localized
- * android.R strings, so no new string resources are needed.
+ * Shared chrome + placement for both selection menus: a Material surface with
+ * a horizontally-scrollable row of buttons, positioned above [rect] (in this
+ * window's coordinates — the popup content fills its window), falling back to
+ * below the rect when there is no room above, clamped to the window
+ * horizontally.
  */
 @Composable
-private fun TextSelectionMenu(
-    request: TextSelectionMenuRequest,
+private fun SelectionMenuSurface(
+    rect: Rect,
     modifier: Modifier = Modifier,
+    buttons: @Composable () -> Unit,
 ) {
     val margin = with(LocalDensity.current) { 8.dp.roundToPx() }
     Layout(
@@ -527,25 +652,14 @@ private fun TextSelectionMenu(
                 tonalElevation = 3.dp,
                 shadowElevation = 6.dp,
             ) {
-                // horizontalScroll: on very narrow windows four buttons can
+                // horizontalScroll: on very narrow windows the buttons can
                 // exceed the width; the native toolbar overflows into a "⋮"
                 // menu, we just let the row scroll instead.
                 Row(
                     modifier = Modifier.horizontalScroll(rememberScrollState()),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    request.onCutRequested?.let {
-                        TextSelectionMenuButton(android.R.string.cut, it)
-                    }
-                    request.onCopyRequested?.let {
-                        TextSelectionMenuButton(android.R.string.copy, it)
-                    }
-                    request.onPasteRequested?.let {
-                        TextSelectionMenuButton(android.R.string.paste, it)
-                    }
-                    request.onSelectAllRequested?.let {
-                        TextSelectionMenuButton(android.R.string.selectAll, it)
-                    }
+                    buttons()
                 }
             }
         },
@@ -556,26 +670,89 @@ private fun TextSelectionMenu(
         )
         layout(constraints.maxWidth, constraints.maxHeight) {
             val maxX = (constraints.maxWidth - placeable.width).coerceAtLeast(0)
-            val x = (request.rect.center.x - placeable.width / 2f)
+            val x = (rect.center.x - placeable.width / 2f)
                 .roundToInt()
                 .coerceIn(0, maxX)
             val maxY = (constraints.maxHeight - placeable.height).coerceAtLeast(0)
-            val yAbove = (request.rect.top - margin - placeable.height).roundToInt()
+            val yAbove = (rect.top - margin - placeable.height).roundToInt()
             val y = if (yAbove >= 0) {
                 yAbove
             } else {
-                (request.rect.bottom + margin).roundToInt().coerceIn(0, maxY)
+                (rect.bottom + margin).roundToInt().coerceIn(0, maxY)
             }
             placeable.place(x, y)
         }
     }
 }
 
+/**
+ * The floating Copy/Cut/Paste/Select-all menu for [FloatingInputTextToolbar]
+ * (OLD context-menu system — dormant on the pinned Compose version, see that
+ * class's docs). Button order matches the platform ActionMode toolbar (Cut,
+ * Copy, Paste, Select all) and labels reuse the system's own localized
+ * android.R strings, so no new string resources are needed.
+ */
 @Composable
-private fun TextSelectionMenuButton(labelRes: Int, onClick: () -> Unit) {
+private fun TextSelectionMenu(
+    request: TextSelectionMenuRequest,
+    modifier: Modifier = Modifier,
+) {
+    SelectionMenuSurface(rect = request.rect, modifier = modifier) {
+        request.onCutRequested?.let {
+            TextSelectionMenuButton(stringResource(android.R.string.cut), it)
+        }
+        request.onCopyRequested?.let {
+            TextSelectionMenuButton(stringResource(android.R.string.copy), it)
+        }
+        request.onPasteRequested?.let {
+            TextSelectionMenuButton(stringResource(android.R.string.paste), it)
+        }
+        request.onSelectAllRequested?.let {
+            TextSelectionMenuButton(stringResource(android.R.string.selectAll), it)
+        }
+    }
+}
+
+/**
+ * The floating selection menu for [FloatingInputTextContextMenuProvider]
+ * (NEW context-menu system — the active one on the pinned foundation
+ * 1.11.4). Unlike the old-system menu, the items here — labels (already
+ * localized), applicability and click behavior included — come from the text
+ * field itself via [FloatingInputContextMenuRequest.dataProvider]; each
+ * item's own `onClick` performs the edit and closes the session. Component
+ * types this menu doesn't understand (e.g. smart-selection text-
+ * classification items) are skipped rather than crashed on.
+ */
+@Composable
+private fun TextContextMenuOverlay(
+    request: FloatingInputContextMenuRequest,
+    destinationCoordinates: LayoutCoordinates,
+    modifier: Modifier = Modifier,
+) {
+    val components = request.dataProvider.data().components
+    if (components.none { it is TextContextMenuItem }) return
+    val rect = request.dataProvider.contentBounds(destinationCoordinates)
+    SelectionMenuSurface(rect = rect, modifier = modifier) {
+        components.forEach { component ->
+            when (component) {
+                is TextContextMenuItem -> TextSelectionMenuButton(
+                    label = component.label,
+                    onClick = { component.onClick(request.session) },
+                )
+                is TextContextMenuSeparator -> VerticalDivider(
+                    modifier = Modifier.height(24.dp),
+                )
+                else -> Unit
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextSelectionMenuButton(label: String, onClick: () -> Unit) {
     TextButton(onClick = onClick) {
         Text(
-            text = stringResource(labelRes),
+            text = label,
             style = MaterialTheme.typography.labelLarge,
         )
     }

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/FloatingTextInputDialog.kt
@@ -28,6 +28,7 @@ import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,6 +41,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -49,25 +51,34 @@ import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalTextToolbar
+import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.TextToolbarStatus
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.contentDescription
@@ -153,6 +164,74 @@ private const val MIN_HEIGHT_DP = 80f
 private const val A11Y_STEP_RATIO = 0.1f
 
 /**
+ * One selection-menu request captured from Compose's text-selection machinery:
+ * where the selection is (in the popup content's root coordinates) and which
+ * actions currently apply. A null callback means the machinery considers that
+ * action inapplicable right now (e.g. Paste with an empty clipboard, Select
+ * all when everything is already selected) — the menu simply omits the button,
+ * mirroring what the platform ActionMode toolbar does.
+ *
+ * Internal (not private) so unit tests can drive [FloatingInputTextToolbar]
+ * directly.
+ */
+internal class TextSelectionMenuRequest(
+    val rect: Rect,
+    val onCopyRequested: (() -> Unit)?,
+    val onPasteRequested: (() -> Unit)?,
+    val onCutRequested: (() -> Unit)?,
+    val onSelectAllRequested: (() -> Unit)?,
+)
+
+/**
+ * Replacement for Compose's default ActionMode-backed text toolbar, needed
+ * because this dialog's TextField lives inside a focusable [Popup]: a popup
+ * window has no real DecorView, so `View.startActionMode(TYPE_FLOATING)` —
+ * which the default `AndroidTextToolbar` relies on — silently does nothing
+ * there, and the Copy/Cut/Paste/Select-all toolbar never appears (no crash,
+ * no log; see docs/plans/floating-text-input-toolbar-fix.md). Provided via
+ * `LocalTextToolbar` scoped to just the TextField.
+ *
+ * This class only *captures* the show/hide requests as snapshot state; the
+ * menu itself is rendered by [TextSelectionMenu] inside the popup's own
+ * window — deliberately NOT another Popup window, so there is no second
+ * focusable window to recreate the same focus conflict one level down.
+ *
+ * Signature verified against androidx.compose.ui:ui 1.11.4 (the version the
+ * pinned compose-bom 2026.06.01 resolves to): the abstract `showMenu` takes
+ * (rect, onCopy, onPaste, onCut, onSelectAll), all callbacks nullable; the
+ * 5-callback `onAutofillRequested` overload is an interface default that
+ * delegates here, so it needs no override (this menu offers no Autofill
+ * entry, matching the pre-fix behavior of this dialog).
+ */
+internal class FloatingInputTextToolbar : TextToolbar {
+    var menuRequest by mutableStateOf<TextSelectionMenuRequest?>(null)
+        private set
+
+    override val status: TextToolbarStatus
+        get() = if (menuRequest != null) TextToolbarStatus.Shown else TextToolbarStatus.Hidden
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?,
+    ) {
+        menuRequest = TextSelectionMenuRequest(
+            rect = rect,
+            onCopyRequested = onCopyRequested,
+            onPasteRequested = onPasteRequested,
+            onCutRequested = onCutRequested,
+            onSelectAllRequested = onSelectAllRequested,
+        )
+    }
+
+    override fun hide() {
+        menuRequest = null
+    }
+}
+
+/**
  * Floating, draggable, resizable text-entry window over the terminal: type a
  * full command/line with the normal IME (autocorrect, swipe typing, voice
  * input, cursor movement), review it, then send the whole string to the
@@ -201,6 +280,11 @@ internal fun FloatingTextInputDialog(
     var windowHeightPx by remember { mutableFloatStateOf(screenHeightPx * savedHeight) }
 
     val textFieldFocusRequester = remember { FocusRequester() }
+
+    // Custom selection toolbar (Copy/Cut/Paste/Select all) — the platform
+    // ActionMode one never shows inside this focusable Popup; see the class
+    // docs on FloatingInputTextToolbar.
+    val selectionTextToolbar = remember { FloatingInputTextToolbar() }
 
     // Focus the field as soon as the window opens so typing can start
     // immediately.
@@ -331,28 +415,34 @@ internal fun FloatingTextInputDialog(
                         .fillMaxWidth()
                         .height(with(density) { (windowHeightPx - 36.dp.toPx()).coerceAtLeast(minHeightPx).toDp() }),
                 ) {
-                    TextField(
-                        value = text,
-                        onValueChange = onTextChange,
-                        placeholder = {
-                            Text(stringResource(R.string.terminal_text_input_placeholder))
-                        },
-                        keyboardOptions = KeyboardOptions(
-                            keyboardType = KeyboardType.Text,
-                        ),
-                        visualTransformation = SpecialCharVisualTransformation,
-                        colors = TextFieldDefaults.colors(
-                            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent,
-                        ),
-                        shape = RoundedCornerShape(bottomStart = 12.dp),
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .focusRequester(textFieldFocusRequester),
-                    )
+                    // LocalTextToolbar is scoped to just this TextField: the
+                    // selection machinery inside it routes its ActionMode
+                    // requests to our toolbar, while everything else in the
+                    // dialog keeps the ambient default.
+                    CompositionLocalProvider(LocalTextToolbar provides selectionTextToolbar) {
+                        TextField(
+                            value = text,
+                            onValueChange = onTextChange,
+                            placeholder = {
+                                Text(stringResource(R.string.terminal_text_input_placeholder))
+                            },
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Text,
+                            ),
+                            visualTransformation = SpecialCharVisualTransformation,
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                focusedIndicatorColor = Color.Transparent,
+                                unfocusedIndicatorColor = Color.Transparent,
+                            ),
+                            shape = RoundedCornerShape(bottomStart = 12.dp),
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .focusRequester(textFieldFocusRequester),
+                        )
+                    }
 
                     Column(
                         modifier = Modifier
@@ -400,6 +490,93 @@ internal fun FloatingTextInputDialog(
                     }
                 }
             }
+
+            // Selection menu, rendered INSIDE this popup's own window (a
+            // sibling drawn after — therefore above — the dialog itself).
+            // Not a nested Popup/PopupWindow on purpose: a second window
+            // would reintroduce the exact focus/window problem this replaces.
+            // The empty area of the overlay doesn't consume touches, so the
+            // scrim's tap-outside-to-dismiss keeps working.
+            selectionTextToolbar.menuRequest?.let { request ->
+                TextSelectionMenu(request = request)
+            }
         }
+    }
+}
+
+/**
+ * The floating Copy/Cut/Paste/Select-all menu for [FloatingInputTextToolbar].
+ * Positioned above the selection rect ([TextSelectionMenuRequest.rect], in
+ * root coordinates — the popup content fills its window, so root == window),
+ * falling back to below the rect when there is no room above, clamped to the
+ * window horizontally. Button order matches the platform ActionMode toolbar
+ * (Cut, Copy, Paste, Select all) and labels reuse the system's own localized
+ * android.R strings, so no new string resources are needed.
+ */
+@Composable
+private fun TextSelectionMenu(
+    request: TextSelectionMenuRequest,
+    modifier: Modifier = Modifier,
+) {
+    val margin = with(LocalDensity.current) { 8.dp.roundToPx() }
+    Layout(
+        content = {
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.surface,
+                tonalElevation = 3.dp,
+                shadowElevation = 6.dp,
+            ) {
+                // horizontalScroll: on very narrow windows four buttons can
+                // exceed the width; the native toolbar overflows into a "⋮"
+                // menu, we just let the row scroll instead.
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    request.onCutRequested?.let {
+                        TextSelectionMenuButton(android.R.string.cut, it)
+                    }
+                    request.onCopyRequested?.let {
+                        TextSelectionMenuButton(android.R.string.copy, it)
+                    }
+                    request.onPasteRequested?.let {
+                        TextSelectionMenuButton(android.R.string.paste, it)
+                    }
+                    request.onSelectAllRequested?.let {
+                        TextSelectionMenuButton(android.R.string.selectAll, it)
+                    }
+                }
+            }
+        },
+        modifier = modifier.fillMaxSize(),
+    ) { measurables, constraints ->
+        val placeable = measurables.first().measure(
+            constraints.copy(minWidth = 0, minHeight = 0),
+        )
+        layout(constraints.maxWidth, constraints.maxHeight) {
+            val maxX = (constraints.maxWidth - placeable.width).coerceAtLeast(0)
+            val x = (request.rect.center.x - placeable.width / 2f)
+                .roundToInt()
+                .coerceIn(0, maxX)
+            val maxY = (constraints.maxHeight - placeable.height).coerceAtLeast(0)
+            val yAbove = (request.rect.top - margin - placeable.height).roundToInt()
+            val y = if (yAbove >= 0) {
+                yAbove
+            } else {
+                (request.rect.bottom + margin).roundToInt().coerceIn(0, maxY)
+            }
+            placeable.place(x, y)
+        }
+    }
+}
+
+@Composable
+private fun TextSelectionMenuButton(labelRes: Int, onClick: () -> Unit) {
+    TextButton(onClick = onClick) {
+        Text(
+            text = stringResource(labelRes),
+            style = MaterialTheme.typography.labelLarge,
+        )
     }
 }

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/FloatingInputTextContextMenuProviderTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/FloatingInputTextContextMenuProviderTest.kt
@@ -1,0 +1,126 @@
+package sh.haven.feature.terminal
+
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuData
+import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuDataProvider
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * State-contract tests for [FloatingInputTextContextMenuProvider], the
+ * `TextContextMenuProvider` that replaces the (silently broken inside a
+ * focusable Popup) platform ActionMode toolbar on the NEW flag-gated
+ * context-menu system — the one that is actually active on the pinned
+ * foundation 1.11.4 (`ComposeFoundationFlags.isNewContextMenuEnabled`
+ * compiles to `true` there).
+ *
+ * These are plain-JVM coroutine tests: they prove the suspend/session/state
+ * contract (show parks a request, close/cancel resolves and clears it,
+ * concurrent shows don't clobber each other). What they can NOT prove is
+ * that Compose's selection machinery actually calls this provider on a real
+ * device, nor that the menu renders and is tappable — this module has no
+ * Robolectric/compose-ui-test setup, so that part needs a real
+ * device/emulator (see docs/plans/floating-text-input-toolbar-fix.md).
+ */
+class FloatingInputTextContextMenuProviderTest {
+
+    private class FakeDataProvider : TextContextMenuDataProvider {
+        override fun position(destinationCoordinates: LayoutCoordinates): Offset = Offset.Zero
+
+        override fun contentBounds(destinationCoordinates: LayoutCoordinates): Rect = Rect.Zero
+
+        override fun data(): TextContextMenuData = TextContextMenuData(emptyList())
+    }
+
+    @Test
+    fun `showTextContextMenu parks a request with the given data provider`() = runTest {
+        val provider = FloatingInputTextContextMenuProvider()
+        val dataProvider = FakeDataProvider()
+        assertNull(provider.request)
+
+        val job = launch { provider.showTextContextMenu(dataProvider) }
+        testScheduler.runCurrent()
+
+        val request = provider.request
+        assertNotNull(request)
+        assertSame(dataProvider, request!!.dataProvider)
+        assertTrue(job.isActive) // still suspended while the menu is "shown"
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `closing the session resumes the suspend and clears the request`() = runTest {
+        val provider = FloatingInputTextContextMenuProvider()
+        val job = launch { provider.showTextContextMenu(FakeDataProvider()) }
+        testScheduler.runCurrent()
+        val request = provider.request
+        assertNotNull(request)
+
+        request!!.session.close()
+        job.join()
+
+        assertTrue(job.isCompleted)
+        assertNull(provider.request)
+    }
+
+    @Test
+    fun `double close is harmless`() = runTest {
+        val provider = FloatingInputTextContextMenuProvider()
+        val job = launch { provider.showTextContextMenu(FakeDataProvider()) }
+        testScheduler.runCurrent()
+        val session = provider.request!!.session
+
+        session.close()
+        session.close() // must not throw or double-resume
+        job.join()
+
+        assertNull(provider.request)
+    }
+
+    @Test
+    fun `cancellation by the caller clears the request`() = runTest {
+        // This is the hide() path: TextContextMenuToolbarHandlerNode cancels
+        // the coroutine when the selection machinery wants the menu gone.
+        val provider = FloatingInputTextContextMenuProvider()
+        val job = launch { provider.showTextContextMenu(FakeDataProvider()) }
+        testScheduler.runCurrent()
+        assertNotNull(provider.request)
+
+        job.cancelAndJoin()
+
+        assertNull(provider.request)
+    }
+
+    @Test
+    fun `a newer concurrent show replaces the request and survives the older call's teardown`() = runTest {
+        val provider = FloatingInputTextContextMenuProvider()
+        val first = launch { provider.showTextContextMenu(FakeDataProvider()) }
+        testScheduler.runCurrent()
+        val firstRequest = provider.request
+        assertNotNull(firstRequest)
+
+        val secondData = FakeDataProvider()
+        val second = launch { provider.showTextContextMenu(secondData) }
+        testScheduler.runCurrent()
+        val secondRequest = provider.request
+        assertNotNull(secondRequest)
+        assertTrue(firstRequest !== secondRequest)
+        assertSame(secondData, secondRequest!!.dataProvider)
+
+        // The older call being torn down must NOT wipe the newer request.
+        first.cancelAndJoin()
+        assertSame(secondRequest, provider.request)
+
+        second.cancelAndJoin()
+        assertNull(provider.request)
+    }
+}

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/FloatingInputTextToolbarTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/FloatingInputTextToolbarTest.kt
@@ -1,0 +1,96 @@
+package sh.haven.feature.terminal
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.TextToolbarStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * State-contract tests for [FloatingInputTextToolbar], the custom
+ * `TextToolbar` that replaces the (silently broken inside a focusable Popup)
+ * platform ActionMode toolbar for the floating text input dialog.
+ *
+ * These are plain-JVM tests: `androidx.compose.ui.geometry.Rect` and the
+ * snapshot-state machinery both run without an Android runtime. What they can
+ * NOT prove is that the menu actually renders and is tappable — this module
+ * has no Robolectric/compose-ui-test setup, so that part needs a real
+ * device/emulator (see docs/plans/floating-text-input-toolbar-fix.md,
+ * "What to verify before calling this done").
+ */
+class FloatingInputTextToolbarTest {
+
+    private val rect = Rect(10f, 20f, 110f, 60f)
+
+    @Test
+    fun `starts hidden with no menu request`() {
+        val toolbar = FloatingInputTextToolbar()
+        assertEquals(TextToolbarStatus.Hidden, toolbar.status)
+        assertNull(toolbar.menuRequest)
+    }
+
+    @Test
+    fun `showMenu exposes request, status and pass-through callbacks`() {
+        val toolbar = FloatingInputTextToolbar()
+        var copied = false
+        var selectedAll = false
+
+        toolbar.showMenu(
+            rect = rect,
+            onCopyRequested = { copied = true },
+            onPasteRequested = null,
+            onCutRequested = null,
+            onSelectAllRequested = { selectedAll = true },
+        )
+
+        assertEquals(TextToolbarStatus.Shown, toolbar.status)
+        val request = toolbar.menuRequest
+        assertNotNull(request)
+        request!!
+        assertEquals(rect, request.rect)
+
+        // Applicable actions pass straight through to the machinery's
+        // callbacks; inapplicable ones (null) stay null so the menu can
+        // omit those buttons, like the platform toolbar does.
+        assertNotNull(request.onCopyRequested)
+        assertNotNull(request.onSelectAllRequested)
+        assertNull(request.onPasteRequested)
+        assertNull(request.onCutRequested)
+
+        request.onCopyRequested!!.invoke()
+        request.onSelectAllRequested!!.invoke()
+        assertTrue(copied)
+        assertTrue(selectedAll)
+    }
+
+    @Test
+    fun `hide clears the request and reports hidden`() {
+        val toolbar = FloatingInputTextToolbar()
+        toolbar.showMenu(rect, { }, { }, { }, { })
+        assertEquals(TextToolbarStatus.Shown, toolbar.status)
+
+        toolbar.hide()
+
+        assertEquals(TextToolbarStatus.Hidden, toolbar.status)
+        assertNull(toolbar.menuRequest)
+    }
+
+    @Test
+    fun `subsequent showMenu replaces the previous request`() {
+        val toolbar = FloatingInputTextToolbar()
+        toolbar.showMenu(rect, { }, null, null, null)
+        val first = toolbar.menuRequest
+
+        val newRect = Rect(0f, 0f, 50f, 25f)
+        toolbar.showMenu(newRect, null, { }, null, null)
+        val second = toolbar.menuRequest
+
+        assertNotNull(second)
+        assertTrue(first !== second)
+        assertEquals(newRect, second!!.rect)
+        assertNull(second.onCopyRequested)
+        assertNotNull(second.onPasteRequested)
+    }
+}


### PR DESCRIPTION
## Summary

The floating Text Input dialog (`FloatingTextInputDialog.kt`, landed in #439) lets you select
text — selection handles appear — but the native Copy/Cut/Paste/Select-all toolbar never shows
up, found on a real device.

## Root cause

The dialog's `TextField` lives inside a focusable `Popup` (deliberate — see #439's design doc,
isolated pointer-input dispatch). Disassembled the actual pinned `androidx.compose.foundation`
1.11.4 AAR (via compose-bom 2026.06.01) to confirm rather than guess:
`ComposeFoundationFlags.isNewContextMenuEnabled` compiles to `true` by default, and when true the
selection machinery never calls `TextToolbar.showMenu()` — it routes through a parallel
`TextContextMenuProvider` pipeline instead. The platform default provider for *that* system
(`AndroidTextContextMenuToolbarProvider`) is `ActionMode`-based, which silently no-ops inside a
focusable `Popup` (no real `DecorView`) — same failure class as the legacy path, just on the
system that's actually active on this Compose version.

Material3's `TextField` follows the same path: M3 1.4.0 has no context-menu wiring of its own and
delegates to the legacy `CoreTextField`, which is flag-gated the same way.

## Fix

`FloatingInputTextContextMenuProvider` (a `TextContextMenuProvider`) renders the menu as a sibling
inside the dialog's own popup window instead of via `ActionMode` — no second focusable window, so
no recursion of the original problem. Menu items (labels, applicability, click behavior) come
straight from the field itself via `TextContextMenuDataProvider.data()`, so it automatically tracks
whatever the platform TextField would normally offer (Cut/Copy/Paste/Select-all, plus e.g. "Read
aloud" where available) rather than a hardcoded 4-item list.

Provided for **both** `LocalTextContextMenuToolbarProvider` and `LocalTextContextMenuDropdownProvider`
— the field's internal default-installer only respects an outside provider when both locals are
non-null (verified in the 1.11.4 bytecode), so providing only one gets silently shadowed back to
the broken platform default.

Kept a `LocalTextToolbar` implementation too (small, already tested) as a fallback for Compose
configs where the flag is false — dormant on this pinned version, cheap to keep.

No `ComposeFoundationFlags` mutation anywhere — the whole fix is scoped to composition locals
around the one `TextField`, nothing else in the app is affected.

## History (kept honest rather than squashed)

First attempt (this PR's first commit) shipped only the `LocalTextToolbar` override, reasoned to
be correct, unit-tested, and confirmed on a real device to do **nothing** — the flag findings
above are exactly why. Second commit is the actual fix, verified on a real device this time
(screenshot: Cut/Copy/Paste/Select all/Read aloud all appear and are positioned correctly over the
selection).

## Test plan

- [x] Real device: select text in the dialog → toolbar appears positioned over the selection,
      each button works (screenshot confirms Cut/Copy/Paste/Select all/Read aloud all present).
- [x] `feature:terminal` unit tests: 104/104 pass (10 new state-contract tests across both
      providers).
- [x] Confirmed unchanged: bracket-paste send path, drag-to-move, resize, TalkBack custom actions,
      tap-outside-dismiss.
- [ ] TalkBack with the new menu specifically (pre-existing gap from #439, not newly introduced
      here) — not yet verified with a real screen reader.