### PR TITLE
feat(terminal): Save connection pins live multiplexer session to a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ the corresponding GitHub Release; a release can't ship without its section
 (enforced by `scripts/check-changelog.sh` in CI). The GitHub "Full Changelog"
 compare link is appended automatically — don't add it here.
 
+## Unreleased
+
+🔌 **Terminal: Save connection pins the live session as a one-tap profile** — long-press a terminal tab → **Save connection** opens a confirm dialog (editable **Name**, read-only **ID**, OK/Cancel). OK clones the live SSH/Mosh/ET host/auth into a Connections profile and pins the multiplexer session via `remoteCommand` (`tmux new -A -s …` / zellij / screen / byobu), so a cold tap re-attaches without the session picker. Same name + host + user upserts the pin instead of duplicating. Distinct from `lastSessionName` reconnect memory: this is an explicit save that closes the loop. (thanks kanazawahere)
+
 ## v5.83.10
 
 🌐 **Local Linux: the guest DNS setting now also covers package installs** — v5.83.9 made the guest's name servers configurable, but only refreshed `/etc/resolv.conf` when a *terminal* session started or a distro was installed. Installing a desktop (or anything else run inside the guest) goes down a different path, so on an existing distro those commands could still use the stale file — which is exactly the "installing Xfce silently hangs" case the setting was added to fix. Every command run in the guest now refreshes the resolver first. (#446)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ compare link is appended automatically — don't add it here.
 
 ## Unreleased
 
-🔌 **Terminal: Save connection pins the live session as a one-tap profile** — long-press a terminal tab → **Save connection** opens a confirm dialog (editable **Name**, read-only **ID**, OK/Cancel). OK clones the live SSH/Mosh/ET host/auth into a Connections profile and pins the multiplexer session via `remoteCommand` (`tmux new -A -s …` / zellij / screen / byobu), so a cold tap re-attaches without the session picker. Same name + host + user upserts the pin instead of duplicating. Distinct from `lastSessionName` reconnect memory: this is an explicit save that closes the loop. (thanks kanazawahere)
+📍 **Terminal: Details — where am I? (door · path · room)** — long-press a terminal tab → **Details** shows the three layers that are easy to lose track of on a phone: **door** (connection card label/id/host), **path** (SSH / Mosh / Eternal Terminal), and **room** (live multiplexer session vs the card's remoteCommand pin). A mismatch is highlighted so a detour into an auto-created session is obvious. **Copy** puts the full sitrep on the clipboard for support. (thanks kanazawahere)
+
+🔌 **Terminal: Save connection pins the live session as a one-tap profile** — long-press a terminal tab → **Save connection** opens a confirm dialog with door/path/room context, editable **card name**, read-only **profile id**, and an explicit warning when the live room differs from the card pin (save repins to the live room). OK clones host/auth and writes `remoteCommand` (`tmux new -A -s …` / zellij / screen / byobu). Same name + host + user upserts instead of duplicating. Distinct from `lastSessionName` reconnect memory. (thanks kanazawahere)
 
 ## v5.83.10
 

--- a/core/local/src/main/kotlin/sh/haven/core/local/ProotDns.kt
+++ b/core/local/src/main/kotlin/sh/haven/core/local/ProotDns.kt
@@ -1,5 +1,6 @@
 package sh.haven.core.local
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.util.Log

--- a/core/local/src/main/kotlin/sh/haven/core/local/ProotDns.kt
+++ b/core/local/src/main/kotlin/sh/haven/core/local/ProotDns.kt
@@ -97,6 +97,7 @@ object ProotDns {
         nameservers.joinToString(separator = "") { "nameserver $it\n" }
 
     /** The device's current resolvers, newest-network-first; empty when unavailable. */
+    @SuppressLint("MissingPermission") // ACCESS_NETWORK_STATE declared in app manifest
     fun systemNameservers(context: Context): List<String> = try {
         val manager = context.getSystemService(ConnectivityManager::class.java)
         val network = manager?.activeNetwork

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -37176,7 +37176,56 @@
     },
     {
      "name": "terminal_save_connection_id",
-     "en": "ID",
+     "en": "Profile ID",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_id_hint",
+     "en": "Stable card key — not the room name",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_name_label",
+     "en": "Card name",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_name_hint",
+     "en": "Label on the Connections list (door)",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_context",
+     "en": "Door: %1$s\\nPath: %2$s\\nRoom to pin: %3$s",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [
+      "%1$s",
+      "%2$s",
+      "%3$s"
+     ],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_mismatch",
+     "en": "This card is pinned to room \\\"%1$s\\\" but you are in \\\"%2$s\\\". Saving will repin the card to the live room.",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [
+      "%1$s",
+      "%2$s"
+     ],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_update",
+     "en": "Update pin",
      "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {}
@@ -37207,9 +37256,95 @@
      "t": {}
     },
     {
+     "name": "terminal_details",
+     "en": "Details",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_title",
+     "en": "Where am I?",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_door",
+     "en": "Door (connection card)",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_path",
+     "en": "Path (transport)",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_room",
+     "en": "Room (tmux / session)",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_room_unknown",
+     "en": "— unknown —",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_room_pin",
+     "en": "Card pin: %1$s",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [
+      "%1$s"
+     ],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_room_no_pin",
+     "en": "— none —",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_room_mismatch",
+     "en": "Live room differs from the card pin — you may have entered through a different door or landed in an auto-created session.",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_copy",
+     "en": "Copy",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_copied",
+     "en": "Copied whereabouts",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_details_unavailable",
+     "en": "Couldn\\'t read connection details for this tab.",
+     "comment": "Details / where am I (door · path · room)",
+     "args": [],
+     "t": {}
+    },
+    {
      "name": "terminal_enter_fullscreen",
      "en": "Enter fullscreen",
-     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "comment": "Details / where am I (door · path · room)",
      "args": [],
      "t": {
       "ar": "الدخول إلى وضع ملء الشاشة",
@@ -37228,7 +37363,7 @@
     {
      "name": "terminal_exit_fullscreen",
      "en": "Exit fullscreen",
-     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "comment": "Details / where am I (door · path · room)",
      "args": [],
      "t": {
       "ar": "الخروج من وضع ملء الشاشة",
@@ -37247,7 +37382,7 @@
     {
      "name": "terminal_vnc_username_label",
      "en": "Username (optional — VeNCrypt only)",
-     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "comment": "Details / where am I (door · path · room)",
      "args": [],
      "t": {
       "ar": "Username (optional — VeNCrypt only)",
@@ -37266,7 +37401,7 @@
     {
      "name": "terminal_vnc_username_placeholder",
      "en": "Leave blank for classic VncAuth",
-     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "comment": "Details / where am I (door · path · room)",
      "args": [],
      "t": {
       "ar": "Leave blank for classic VncAuth",
@@ -37285,7 +37420,7 @@
     {
      "name": "terminal_vnc_color_depth",
      "en": "Colour depth",
-     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "comment": "Details / where am I (door · path · room)",
      "args": [],
      "t": {
       "ar": "Colour depth",

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -37201,7 +37201,7 @@
     },
     {
      "name": "terminal_save_connection_need_session",
-     "en": "Attach a multiplexer session first (tmux / zellij / screen / byobu)",
+     "en": "Couldn\\'t detect a session name for this tab. Open a named tmux/zellij/screen session, or set Remote command on the profile, then try Save connection again.",
      "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {}

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -37161,9 +37161,55 @@
      }
     },
     {
+     "name": "terminal_save_connection",
+     "en": "Save connection",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_title",
+     "en": "Save connection",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_id",
+     "en": "ID",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_saved",
+     "en": "Saved connection \\\"%1$s\\\"",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [
+      "%1$s"
+     ],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_updated",
+     "en": "Updated connection \\\"%1$s\\\"",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [
+      "%1$s"
+     ],
+     "t": {}
+    },
+    {
+     "name": "terminal_save_connection_need_session",
+     "en": "Attach a multiplexer session first (tmux / zellij / screen / byobu)",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
+     "args": [],
+     "t": {}
+    },
+    {
      "name": "terminal_enter_fullscreen",
      "en": "Enter fullscreen",
-     "comment": "RenameSessionDialog",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {
       "ar": "الدخول إلى وضع ملء الشاشة",
@@ -37182,7 +37228,7 @@
     {
      "name": "terminal_exit_fullscreen",
      "en": "Exit fullscreen",
-     "comment": "RenameSessionDialog",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {
       "ar": "الخروج من وضع ملء الشاشة",
@@ -37201,7 +37247,7 @@
     {
      "name": "terminal_vnc_username_label",
      "en": "Username (optional — VeNCrypt only)",
-     "comment": "RenameSessionDialog",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {
       "ar": "Username (optional — VeNCrypt only)",
@@ -37220,7 +37266,7 @@
     {
      "name": "terminal_vnc_username_placeholder",
      "en": "Leave blank for classic VncAuth",
-     "comment": "RenameSessionDialog",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {
       "ar": "Leave blank for classic VncAuth",
@@ -37239,7 +37285,7 @@
     {
      "name": "terminal_vnc_color_depth",
      "en": "Colour depth",
-     "comment": "RenameSessionDialog",
+     "comment": "Save connection (pin live session onto a profile for one-tap reconnect)",
      "args": [],
      "t": {
       "ar": "Colour depth",

--- a/feature/connections/src/main/kotlin/sh/haven/feature/connections/ConnectionsViewModel.kt
+++ b/feature/connections/src/main/kotlin/sh/haven/feature/connections/ConnectionsViewModel.kt
@@ -1889,7 +1889,7 @@ class ConnectionsViewModel @Inject constructor(
             return
         }
         if (profile.isEternalTerminal) {
-            connectEternalTerminal(profile, password, keyOnly, usernameOverride = runtimeUsername)
+            connectEternalTerminal(profile, password, keyOnly, usernameOverride = runtimeUsername, startupCommand = startupCommand)
             return
         }
         if (profile.isMosh) {
@@ -3344,6 +3344,7 @@ class ConnectionsViewModel @Inject constructor(
         password: String,
         keyOnly: Boolean,
         usernameOverride: String? = null,
+        startupCommand: String? = null,
     ) {
         val effectiveUsername = usernameOverride?.takeIf { it.isNotBlank() } ?: profile.username
         viewModelScope.launch {
@@ -3374,6 +3375,38 @@ class ConnectionsViewModel @Inject constructor(
 
                 // Phase 2: Resolve session manager, check for existing sessions
                 val smgr = resolveSessionManager(profile)
+
+                val effectiveStartupCommand = startupCommand ?: profile.remoteCommand?.takeIf { it.isNotBlank() }
+                if (effectiveStartupCommand != null) {
+                    if (profile.requestPty) {
+                        finishEtConnect(
+                            sessionId = sessionId,
+                            profile = profile,
+                            client = client,
+                            manager = smgr,
+                            chosenSessionName = null,
+                            verboseLogger = verboseLogger,
+                            startupCommand = effectiveStartupCommand,
+                        )
+                    } else {
+                        userMessageBus.emit(
+                            sh.haven.core.data.message.UserMessage(
+                                "remoteCommand ignored on Eternal Terminal",
+                                sh.haven.core.data.message.UserMessage.Severity.WARNING
+                            )
+                        )
+                        finishEtConnect(
+                            sessionId = sessionId,
+                            profile = profile,
+                            client = client,
+                            manager = smgr,
+                            chosenSessionName = null,
+                            verboseLogger = verboseLogger,
+                            startupCommand = null,
+                        )
+                    }
+                    return@launch
+                }
 
                 val existingSessions = withContext(Dispatchers.IO) {
                     listExistingMultiplexerSessions(smgr) { client.execCommand(it) }
@@ -4272,6 +4305,7 @@ class ConnectionsViewModel @Inject constructor(
         chosenSessionName: String?,
         silent: Boolean = false,
         verboseLogger: SshVerboseLogger? = null,
+        startupCommand: String? = null,
     ) {
         val etPort = profile.etPort
         val (etClientId, etPasskey) = withContext(Dispatchers.IO) {
@@ -4311,7 +4345,9 @@ class ConnectionsViewModel @Inject constructor(
         // Build session manager command with chosen or default session name
         val smCmd = manager.command
         var effectiveSessionName: String? = null
-        if (smCmd != null) {
+        if (startupCommand != null) {
+            etSessionManager.setInitialCommand(sessionId, startupCommand)
+        } else if (smCmd != null) {
             val rawName = chosenSessionName
                 ?: etSessionManager.sessions.value[sessionId]?.label
                 ?: sessionId.take(8)
@@ -5376,7 +5412,40 @@ class ConnectionsViewModel @Inject constructor(
             }
 
             val smgr = resolveSessionManager(profile)
-            finishEtConnect(sessionId, profile, client, smgr, profile.lastSessionName, silent = true, verboseLogger = verboseLogger)
+            val effectiveStartupCommand = profile.remoteCommand?.takeIf { it.isNotBlank() }
+            if (effectiveStartupCommand != null) {
+                if (profile.requestPty) {
+                    finishEtConnect(
+                        sessionId = sessionId,
+                        profile = profile,
+                        client = client,
+                        manager = smgr,
+                        chosenSessionName = profile.lastSessionName,
+                        silent = true,
+                        verboseLogger = verboseLogger,
+                        startupCommand = effectiveStartupCommand,
+                    )
+                } else {
+                    userMessageBus.emit(
+                        sh.haven.core.data.message.UserMessage(
+                            "remoteCommand ignored on Eternal Terminal",
+                            sh.haven.core.data.message.UserMessage.Severity.WARNING
+                        )
+                    )
+                    finishEtConnect(
+                        sessionId = sessionId,
+                        profile = profile,
+                        client = client,
+                        manager = smgr,
+                        chosenSessionName = profile.lastSessionName,
+                        silent = true,
+                        verboseLogger = verboseLogger,
+                        startupCommand = null,
+                    )
+                }
+            } else {
+                finishEtConnect(sessionId, profile, client, smgr, profile.lastSessionName, silent = true, verboseLogger = verboseLogger)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "connectEtSilent failed for ${profile.label}: ${e.message}", e)
             connectionLogRepository.logEvent(profile.id, ConnectionLog.Status.FAILED, details = e.message, verboseLog = verboseLogger?.drain())

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/SaveConnectionFromSession.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/SaveConnectionFromSession.kt
@@ -1,0 +1,193 @@
+package sh.haven.feature.terminal
+
+import sh.haven.core.data.db.entities.ConnectionProfile
+import sh.haven.core.ssh.SessionManager
+import java.util.UUID
+
+/**
+ * Build / upsert a connection profile that pins the live multiplexer session
+ * so a cold tap auto-attaches (same idea as a hand-edited `remoteCommand`
+ * profile). Name is the user-facing label; [profileId] is the stable key.
+ *
+ * Distinct from [ConnectionProfile.lastSessionName] reconnect memory: this
+ * writes an explicit pin via [ConnectionProfile.remoteCommand].
+ */
+object SaveConnectionFromSession {
+
+    data class Draft(
+        /** Proposed / existing profile id (stable; not editable in UI). */
+        val profileId: String,
+        /** Default label = multiplexer session name. */
+        val defaultName: String,
+        /** Multiplexer session name being pinned (sanitized). */
+        val sessionName: String,
+        val sessionManager: SessionManager,
+        val sourceProfileId: String,
+        /** True when [profileId] already exists and OK will update it. */
+        val isUpdate: Boolean,
+    )
+
+    data class Result(
+        val profile: ConnectionProfile,
+        val created: Boolean,
+    )
+
+    /**
+     * Remote-command pin for cold connect. Kept short and shell-simple so it
+     * works over SSH exec and as `mosh-server -- <cmd>` (see #436).
+     */
+    fun pinRemoteCommand(manager: SessionManager, sessionName: String): String? {
+        val name = SessionManager.sanitizeSessionName(sessionName)
+        if (name.isBlank()) return null
+        return when (manager) {
+            SessionManager.NONE -> null
+            SessionManager.TMUX -> "tmux new -A -s $name"
+            SessionManager.ZELLIJ -> "zellij attach $name --create"
+            SessionManager.SCREEN -> "screen -dRR $name"
+            SessionManager.BYOBU -> "byobu new-session -A -s $name"
+        }
+    }
+
+    /**
+     * Prepare dialog state. Upsert target = existing SSH profile with the
+     * same host + username + label (after trim); otherwise a new UUID.
+     */
+    fun draft(
+        source: ConnectionProfile,
+        sessionName: String,
+        manager: SessionManager,
+        existing: List<ConnectionProfile>,
+        defaultLabel: String = sessionName,
+        newId: () -> String = { UUID.randomUUID().toString() },
+    ): Draft? {
+        if (!source.isSsh) return null
+        val sanitized = SessionManager.sanitizeSessionName(sessionName)
+        if (sanitized.isBlank()) return null
+        if (manager == SessionManager.NONE) return null
+        if (pinRemoteCommand(manager, sanitized) == null) return null
+
+        val label = defaultLabel.trim().ifBlank { sanitized }
+        val match = findUpsertTarget(existing, source, label)
+        return Draft(
+            profileId = match?.id ?: newId(),
+            defaultName = label,
+            sessionName = sanitized,
+            sessionManager = manager,
+            sourceProfileId = source.id,
+            isUpdate = match != null,
+        )
+    }
+
+    /**
+     * Resolve the profile to write. [displayName] is the editable dialog name.
+     * Re-runs upsert match so a rename in the dialog can still hit an existing card.
+     */
+    fun build(
+        source: ConnectionProfile,
+        displayName: String,
+        sessionName: String,
+        manager: SessionManager,
+        existing: List<ConnectionProfile>,
+        preferredId: String,
+    ): Result? {
+        if (!source.isSsh) return null
+        val sanitized = SessionManager.sanitizeSessionName(sessionName)
+        val remote = pinRemoteCommand(manager, sanitized) ?: return null
+        val label = displayName.trim().ifBlank { sanitized }
+        if (label.isBlank()) return null
+
+        val match = findUpsertTarget(existing, source, label)
+        val id = match?.id ?: preferredId
+        val created = match == null
+        val sortOrder = match?.sortOrder
+            ?: ((existing.maxOfOrNull { it.sortOrder } ?: -1) + 1)
+
+        val base = match ?: source
+        val profile = base.copy(
+            id = id,
+            label = label,
+            // Keep endpoint/auth from the live source (fresh host/key/mosh).
+            host = source.host,
+            port = source.port,
+            username = source.username,
+            sshPassword = source.sshPassword,
+            authType = source.authType,
+            keyId = source.keyId,
+            authMethods = source.authMethods,
+            totpConfirmBeforeSend = source.totpConfirmBeforeSend,
+            ignoreSavedKeys = source.ignoreSavedKeys,
+            connectionType = "SSH",
+            jumpProfileId = source.jumpProfileId,
+            sshOptions = source.sshOptions,
+            useMosh = source.useMosh,
+            useEternalTerminal = source.useEternalTerminal,
+            etPort = source.etPort,
+            proxyType = source.proxyType,
+            proxyHost = source.proxyHost,
+            proxyPort = source.proxyPort,
+            proxyUser = source.proxyUser,
+            proxyPassword = source.proxyPassword,
+            identityId = source.identityId,
+            groupId = match?.groupId ?: source.groupId,
+            colorTag = match?.colorTag ?: source.colorTag,
+            forwardAgent = source.forwardAgent,
+            addressFamily = source.addressFamily,
+            moshServerCommand = source.moshServerCommand,
+            tunnelConfigId = source.tunnelConfigId,
+            autoReconnect = source.autoReconnect,
+            reconnectMaxAttempts = source.reconnectMaxAttempts,
+            reconnectOnNetworkChange = source.reconnectOnNetworkChange,
+            // Pin: explicit remote command + remembered name.
+            remoteCommand = remote,
+            requestPty = true,
+            lastSessionName = sanitized,
+            sessionManager = manager.name,
+            // Clear interactive post-login so it cannot race the pin.
+            postLoginCommand = null,
+            sortOrder = sortOrder,
+            lastConnected = match?.lastConnected,
+        )
+        return Result(profile = profile, created = created)
+    }
+
+    private fun findUpsertTarget(
+        existing: List<ConnectionProfile>,
+        source: ConnectionProfile,
+        label: String,
+    ): ConnectionProfile? =
+        existing.firstOrNull {
+            it.isSsh &&
+                it.label == label &&
+                it.host == source.host &&
+                it.username == source.username &&
+                it.port == source.port
+        }
+
+    /**
+     * Parse a session name out of a profile [remoteCommand] pin (the simple
+     * forms written by [pinRemoteCommand]). Returns null when the command is
+     * not a known pin shape.
+     */
+    fun sessionNameFromRemoteCommand(remoteCommand: String?): String? {
+        val cmd = remoteCommand?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        // tmux new -A -s NAME  |  byobu new-session -A -s NAME
+        Regex("""(?:tmux|byobu)\s+(?:new(?:-session)?)\s+-A\s+-s\s+(\S+)""")
+            .find(cmd)?.groupValues?.getOrNull(1)?.let { return SessionManager.sanitizeSessionName(it) }
+        // zellij attach NAME --create
+        Regex("""zellij\s+attach\s+(\S+)""")
+            .find(cmd)?.groupValues?.getOrNull(1)?.let { return SessionManager.sanitizeSessionName(it) }
+        // screen -dRR NAME
+        Regex("""screen\s+-dRR\s+(\S+)""")
+            .find(cmd)?.groupValues?.getOrNull(1)?.let { return SessionManager.sanitizeSessionName(it) }
+        return null
+    }
+
+    fun parseSessionManager(name: String?): SessionManager? {
+        if (name.isNullOrBlank()) return null
+        return try {
+            SessionManager.valueOf(name.trim().uppercase())
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+}

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/SaveConnectionFromSession.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/SaveConnectionFromSession.kt
@@ -92,7 +92,7 @@ object SaveConnectionFromSession {
     ): Result? {
         if (!source.isSsh) return null
         val sanitized = SessionManager.sanitizeSessionName(sessionName)
-        val remote = pinRemoteCommand(manager, sanitized) ?: return null
+        val standardRemote = pinRemoteCommand(manager, sanitized) ?: return null
         val label = displayName.trim().ifBlank { sanitized }
         if (label.isBlank()) return null
 
@@ -101,6 +101,15 @@ object SaveConnectionFromSession {
         val created = match == null
         val sortOrder = match?.sortOrder
             ?: ((existing.maxOfOrNull { it.sortOrder } ?: -1) + 1)
+
+        // Fleet/custom pins (e.g. bash …/haven-role-attach dogfood) must not be
+        // clobbered by a re-Save that only re-derives the simple tmux pin — that
+        // was wiping conversation-recovery wrappers and leaving empty shells.
+        val remote = chooseRemoteCommand(
+            standard = standardRemote,
+            sourceRemote = source.remoteCommand,
+            existingRemote = match?.remoteCommand,
+        )
 
         val base = match ?: source
         val profile = base.copy(
@@ -162,6 +171,35 @@ object SaveConnectionFromSession {
                 it.username == source.username &&
                 it.port == source.port
         }
+
+    /**
+     * Prefer a non-standard (fleet/wrapper) remoteCommand already on the card
+     * or live source over the simple multiplexer pin, so Save does not destroy
+     * conversation-recovery hooks.
+     */
+    fun chooseRemoteCommand(
+        standard: String,
+        sourceRemote: String?,
+        existingRemote: String?,
+    ): String {
+        val candidates = listOfNotNull(existingRemote, sourceRemote)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        val custom = candidates.firstOrNull { !isStandardMultiplexerPin(it) }
+        return custom ?: standard
+    }
+
+    /** True when [cmd] is exactly a pin written by [pinRemoteCommand] (simple form). */
+    fun isStandardMultiplexerPin(cmd: String): Boolean {
+        val t = cmd.trim()
+        if (t.isEmpty()) return false
+        // Must parse as a known pin *and* not look like a shell wrapper.
+        if (sessionNameFromRemoteCommand(t) == null) return false
+        if (t.contains("&&") || t.contains(';') || t.contains('|')) return false
+        if (t.startsWith("bash ") || t.startsWith("sh ") || t.contains("haven-role-attach")) return false
+        if (t.contains('/')) return false
+        return true
+    }
 
     /**
      * Parse a session name out of a profile [remoteCommand] pin (the simple

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DesktopWindows
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DriveFileRenameOutline
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.WifiOff
@@ -604,9 +605,16 @@ fun TerminalScreen(
     val saveConnectionUi by viewModel.saveConnectionUi.collectAsState()
     saveConnectionUi?.let { ui ->
         SaveConnectionDialog(
-            draft = ui.draft,
+            ui = ui,
             onDismiss = { viewModel.dismissSaveConnection() },
             onConfirm = { name -> viewModel.confirmSaveConnection(name) },
+        )
+    }
+    val whereaboutsUi by viewModel.whereaboutsUi.collectAsState()
+    whereaboutsUi?.let { w ->
+        WhereaboutsDialog(
+            whereabouts = w,
+            onDismiss = { viewModel.dismissWhereabouts() },
         )
     }
 
@@ -806,12 +814,28 @@ fun TerminalScreen(
                                             Icon(Icons.Filled.Close, null, modifier = Modifier.size(18.dp))
                                         }
                                     }
-                                    // Rename / Save connection — pin live multiplexer session
-                                    // onto a one-tap profile (name editable, id stable).
+                                    // Details (door/path/room) + Rename + Save connection
                                     val renameableName = viewModel.renameableSessionName(tab.sessionId)
                                     val canSaveConnection = viewModel.canSaveConnection(tab.sessionId)
-                                    if (renameableName != null || canSaveConnection) {
+                                    val canShowDetails = viewModel.canShowDetails(tab.sessionId)
+                                    if (renameableName != null || canSaveConnection || canShowDetails) {
                                         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                                    }
+                                    if (canShowDetails) {
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.terminal_details)) },
+                                            leadingIcon = {
+                                                Icon(
+                                                    Icons.Filled.Info,
+                                                    null,
+                                                    modifier = Modifier.size(16.dp),
+                                                )
+                                            },
+                                            onClick = {
+                                                showTabMenu = false
+                                                viewModel.beginShowDetails(tab.sessionId)
+                                            },
+                                        )
                                     }
                                     if (renameableName != null) {
                                         DropdownMenuItem(
@@ -1879,15 +1903,16 @@ private fun RenameSessionDialog(
 }
 
 /**
- * Confirm dialog for Save connection: editable name on top, stable id below,
- * OK / Cancel. Matches the one-tap pin profiles users keep for each role.
+ * Confirm dialog for Save connection: door/path/room context, editable name,
+ * stable profile id, OK / Cancel.
  */
 @Composable
 private fun SaveConnectionDialog(
-    draft: SaveConnectionFromSession.Draft,
+    ui: TerminalViewModel.SaveConnectionUi,
     onDismiss: () -> Unit,
     onConfirm: (String) -> Unit,
 ) {
+    val draft = ui.draft
     var name by remember(draft.profileId, draft.defaultName) {
         mutableStateOf(draft.defaultName)
     }
@@ -1897,19 +1922,48 @@ private fun SaveConnectionDialog(
         title = { Text(stringResource(R.string.terminal_save_connection_title)) },
         text = {
             Column {
+                Text(
+                    text = stringResource(
+                        R.string.terminal_save_connection_context,
+                        ui.doorLabel,
+                        ui.pathTransport,
+                        ui.roomName,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (ui.roomMismatch && ui.roomPinnedOnCard != null) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.terminal_save_connection_mismatch,
+                            ui.roomPinnedOnCard,
+                            ui.roomName,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
-                    label = { Text(stringResource(R.string.terminal_name)) },
+                    label = { Text(stringResource(R.string.terminal_save_connection_name_label)) },
+                    supportingText = {
+                        Text(stringResource(R.string.terminal_save_connection_name_hint))
+                    },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = draft.profileId,
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(R.string.terminal_save_connection_id)) },
+                    supportingText = {
+                        Text(stringResource(R.string.terminal_save_connection_id_hint))
+                    },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -1920,12 +1974,110 @@ private fun SaveConnectionDialog(
                 onClick = { onConfirm(name) },
                 enabled = name.isNotBlank(),
             ) {
-                Text(stringResource(R.string.common_ok))
+                Text(
+                    if (draft.isUpdate) stringResource(R.string.terminal_save_connection_update)
+                    else stringResource(R.string.common_ok),
+                )
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.common_cancel))
+            }
+        },
+    )
+}
+
+/** Read-only door / path / room sitrep for the active terminal tab. */
+@Composable
+private fun WhereaboutsDialog(
+    whereabouts: TerminalViewModel.ConnectionWhereabouts,
+    onDismiss: () -> Unit,
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.terminal_details_title)) },
+        text = {
+            Column {
+                Text(
+                    stringResource(R.string.terminal_details_door),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(whereabouts.doorLabel, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    "${whereabouts.doorUser}@${whereabouts.doorHost}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    whereabouts.doorId,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    stringResource(R.string.terminal_details_path),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(whereabouts.pathTransport, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    whereabouts.pathDetail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    stringResource(R.string.terminal_details_room),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    whereabouts.roomName
+                        ?: stringResource(R.string.terminal_details_room_unknown),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    stringResource(
+                        R.string.terminal_details_room_pin,
+                        whereabouts.roomPinnedOnCard
+                            ?: stringResource(R.string.terminal_details_room_no_pin),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (whereabouts.roomMismatch) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        stringResource(R.string.terminal_details_room_mismatch),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val clip = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clip.setPrimaryClip(
+                        ClipData.newPlainText("haven-whereabouts", whereabouts.summaryText),
+                    )
+                    @Suppress("LocalContextGetResourceValueCall")
+                    android.widget.Toast.makeText(
+                        context,
+                        context.getString(R.string.terminal_details_copied),
+                        android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                },
+            ) {
+                Icon(Icons.Filled.ContentCopy, null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.terminal_details_copy))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_close))
             }
         },
     )

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DesktopWindows
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DriveFileRenameOutline
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.animation.AnimatedVisibility
@@ -600,6 +601,15 @@ fun TerminalScreen(
     LaunchedEffect(showWallpaper) { onTransparentChanged(showWallpaper) }
     DisposableEffect(Unit) { onDispose { onTransparentChanged(false) } }
 
+    val saveConnectionUi by viewModel.saveConnectionUi.collectAsState()
+    saveConnectionUi?.let { ui ->
+        SaveConnectionDialog(
+            draft = ui.draft,
+            onDismiss = { viewModel.dismissSaveConnection() },
+            onConfirm = { name -> viewModel.confirmSaveConnection(name) },
+        )
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         if (tabs.isEmpty()) {
             EmptyTerminalState(
@@ -796,13 +806,14 @@ fun TerminalScreen(
                                             Icon(Icons.Filled.Close, null, modifier = Modifier.size(18.dp))
                                         }
                                     }
-                                    // Rename action for the current tab — only when the underlying SSH
-                                    // session is wrapped in a session manager (tmux/zellij/screen/byobu)
-                                    // that supports rename. Avoids forcing the user to open the picker
-                                    // via a duplicate connection just to rename an existing session.
+                                    // Rename / Save connection — pin live multiplexer session
+                                    // onto a one-tap profile (name editable, id stable).
                                     val renameableName = viewModel.renameableSessionName(tab.sessionId)
-                                    if (renameableName != null) {
+                                    val canSaveConnection = viewModel.canSaveConnection(tab.sessionId)
+                                    if (renameableName != null || canSaveConnection) {
                                         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                                    }
+                                    if (renameableName != null) {
                                         DropdownMenuItem(
                                             text = { Text(stringResource(R.string.common_rename)) },
                                             leadingIcon = {
@@ -815,6 +826,22 @@ fun TerminalScreen(
                                             onClick = {
                                                 showTabMenu = false
                                                 renameDialogFor = renameableName
+                                            },
+                                        )
+                                    }
+                                    if (canSaveConnection) {
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.terminal_save_connection)) },
+                                            leadingIcon = {
+                                                Icon(
+                                                    Icons.Filled.Save,
+                                                    null,
+                                                    modifier = Modifier.size(16.dp),
+                                                )
+                                            },
+                                            onClick = {
+                                                showTabMenu = false
+                                                viewModel.beginSaveConnection(tab.sessionId)
                                             },
                                         )
                                     }
@@ -1841,6 +1868,59 @@ private fun RenameSessionDialog(
                 enabled = label.isNotBlank() && label != currentLabel,
             ) {
                 Text(stringResource(R.string.terminal_rename))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.common_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Confirm dialog for Save connection: editable name on top, stable id below,
+ * OK / Cancel. Matches the one-tap pin profiles users keep for each role.
+ */
+@Composable
+private fun SaveConnectionDialog(
+    draft: SaveConnectionFromSession.Draft,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var name by remember(draft.profileId, draft.defaultName) {
+        mutableStateOf(draft.defaultName)
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.terminal_save_connection_title)) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.terminal_name)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = draft.profileId,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.terminal_save_connection_id)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name) },
+                enabled = name.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.common_ok))
             }
         },
         dismissButton = {

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -2896,6 +2896,172 @@ class TerminalViewModel @Inject constructor(
     }
 
     /**
+     * Draft for "Save connection" — pin the live multiplexer session onto a
+     * connection profile (name editable, id stable).
+     */
+    data class SaveConnectionUi(
+        val draft: SaveConnectionFromSession.Draft,
+        val sourceProfileId: String,
+    )
+
+    private val _saveConnectionUi = MutableStateFlow<SaveConnectionUi?>(null)
+    val saveConnectionUi: StateFlow<SaveConnectionUi?> = _saveConnectionUi.asStateFlow()
+
+    fun dismissSaveConnection() {
+        _saveConnectionUi.value = null
+    }
+
+    /**
+     * Whether the tab menu should offer Save connection. Cheap sync check;
+     * full validation runs in [beginSaveConnection].
+     */
+    fun canSaveConnection(sessionId: String): Boolean {
+        val ssh = sessionManager.getSession(sessionId)
+        if (ssh != null &&
+            ssh.sessionManager != SessionManager.NONE &&
+            !ssh.chosenSessionName.isNullOrBlank()
+        ) {
+            return true
+        }
+        val tab = _tabs.value.find { it.sessionId == sessionId } ?: return false
+        return tab.transportType in setOf("SSH", "MOSH", "ET")
+    }
+
+    /** Open the Save connection confirm dialog for [sessionId]. */
+    fun beginSaveConnection(sessionId: String) {
+        viewModelScope.launch {
+            val pin = resolveSavePin(sessionId)
+            if (pin == null) {
+                _newTabMessage.value =
+                    appContext.getString(R.string.terminal_save_connection_need_session)
+                return@launch
+            }
+            val (source, sessionName, manager) = pin
+            val existing = withContext(Dispatchers.IO) { connectionRepository.getAll() }
+            val draft = SaveConnectionFromSession.draft(
+                source = source,
+                sessionName = sessionName,
+                manager = manager,
+                existing = existing,
+                defaultLabel = sessionName,
+            )
+            if (draft == null) {
+                _newTabMessage.value =
+                    appContext.getString(R.string.terminal_save_connection_need_session)
+                return@launch
+            }
+            _saveConnectionUi.value =
+                SaveConnectionUi(draft = draft, sourceProfileId = source.id)
+        }
+    }
+
+    /**
+     * Persist the draft with the user-edited [displayName]. Upserts by
+     * label+host+user so a second save with the same name updates the pin.
+     */
+    fun confirmSaveConnection(displayName: String) {
+        val ui = _saveConnectionUi.value ?: return
+        viewModelScope.launch {
+            val source = withContext(Dispatchers.IO) {
+                connectionRepository.getById(ui.sourceProfileId)
+            } ?: run {
+                _saveConnectionUi.value = null
+                return@launch
+            }
+            val existing = withContext(Dispatchers.IO) { connectionRepository.getAll() }
+            val result = SaveConnectionFromSession.build(
+                source = source,
+                displayName = displayName,
+                sessionName = ui.draft.sessionName,
+                manager = ui.draft.sessionManager,
+                existing = existing,
+                preferredId = ui.draft.profileId,
+            )
+            if (result == null) {
+                _newTabMessage.value =
+                    appContext.getString(R.string.terminal_save_connection_need_session)
+                _saveConnectionUi.value = null
+                return@launch
+            }
+            withContext(Dispatchers.IO) { connectionRepository.save(result.profile) }
+            _saveConnectionUi.value = null
+            val msgRes = if (result.created) {
+                R.string.terminal_save_connection_saved
+            } else {
+                R.string.terminal_save_connection_updated
+            }
+            _newTabMessage.value = appContext.getString(msgRes, result.profile.label)
+        }
+    }
+
+    /**
+     * Resolve the multiplexer session to pin from a live terminal tab.
+     * Prefers an SSH [SessionManager] attach; falls back to profile
+     * remoteCommand / lastSessionName (Mosh/ET + remoteCommand profiles).
+     */
+    private suspend fun resolveSavePin(
+        sessionId: String,
+    ): Triple<sh.haven.core.data.db.entities.ConnectionProfile, String, SessionManager>? {
+        val tab = _tabs.value.find { it.sessionId == sessionId }
+        val ssh = sessionManager.getSession(sessionId)
+        val profileId = tab?.profileId ?: ssh?.profileId ?: return null
+        val source = withContext(Dispatchers.IO) {
+            connectionRepository.getById(profileId)
+        } ?: return null
+        if (!source.isSsh) return null
+
+        if (ssh != null &&
+            ssh.sessionManager != SessionManager.NONE &&
+            !ssh.chosenSessionName.isNullOrBlank()
+        ) {
+            return Triple(source, ssh.chosenSessionName!!, ssh.sessionManager)
+        }
+
+        // remoteCommand pin (incl. Mosh/ET profiles that skip SessionManager)
+        SaveConnectionFromSession.sessionNameFromRemoteCommand(source.remoteCommand)?.let { name ->
+            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
+                ?: SessionManager.TMUX
+            if (mgr != SessionManager.NONE) return Triple(source, name, mgr)
+        }
+
+        // lastSessionName single (reconnect memory) — still a usable pin target
+        val last = source.lastSessionName
+            ?.split("|")
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            ?.singleOrNull()
+        if (last != null) {
+            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
+                ?: preferencesRepository.sessionManager.first().let {
+                    try {
+                        SessionManager.valueOf(it.name)
+                    } catch (_: IllegalArgumentException) {
+                        SessionManager.TMUX
+                    }
+                }
+            if (mgr != SessionManager.NONE) return Triple(source, last, mgr)
+        }
+
+        // Tab label last resort (often equals the multiplexer name)
+        val label = tab?.label?.trim()?.takeIf { it.isNotEmpty() }
+        if (label != null) {
+            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
+                ?: preferencesRepository.sessionManager.first().let {
+                    try {
+                        SessionManager.valueOf(it.name)
+                    } catch (_: IllegalArgumentException) {
+                        SessionManager.TMUX
+                    }
+                }
+            if (mgr != SessionManager.NONE) {
+                val san = SessionManager.sanitizeSessionName(label)
+                if (san.isNotBlank()) return Triple(source, san, mgr)
+            }
+        }
+        return null
+    }
+
+    /**
      * Rename the tmux/zellij/screen session backing a connected tab — no need
      * to open a duplicate session via the picker. On success, propagates the
      * new name to the profile's lastSessionName + chosenSessionName + tab label.

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -2995,15 +2995,34 @@ class TerminalViewModel @Inject constructor(
     }
 
     /**
+     * Manager to use when writing a pin. Never [SessionManager.NONE] — a save
+     * always needs a real attach command. Global pref NONE still defaults to
+     * tmux (most common), otherwise dogfood of remoteCommand / plain-shell
+     * profiles falsely shows "attach a multiplexer first" while already inside one.
+     */
+    private suspend fun resolveManagerForPin(source: sh.haven.core.data.db.entities.ConnectionProfile): SessionManager {
+        SaveConnectionFromSession.parseSessionManager(source.sessionManager)
+            ?.takeIf { it != SessionManager.NONE }
+            ?.let { return it }
+        return try {
+            val pref = SessionManager.valueOf(preferencesRepository.sessionManager.first().name)
+            if (pref == SessionManager.NONE) SessionManager.TMUX else pref
+        } catch (_: IllegalArgumentException) {
+            SessionManager.TMUX
+        }
+    }
+
+    /**
      * Resolve the multiplexer session to pin from a live terminal tab.
      * Prefers an SSH [SessionManager] attach; falls back to profile
-     * remoteCommand / lastSessionName (Mosh/ET + remoteCommand profiles).
+     * remoteCommand / lastSessionName / tab label (Mosh/ET + remoteCommand).
      */
     private suspend fun resolveSavePin(
         sessionId: String,
     ): Triple<sh.haven.core.data.db.entities.ConnectionProfile, String, SessionManager>? {
         val tab = _tabs.value.find { it.sessionId == sessionId }
         val ssh = sessionManager.getSession(sessionId)
+        // Mosh/ET tabs don't live in SshSessionManager — profileId is only on the tab.
         val profileId = tab?.profileId ?: ssh?.profileId ?: return null
         val source = withContext(Dispatchers.IO) {
             connectionRepository.getById(profileId)
@@ -3017,46 +3036,35 @@ class TerminalViewModel @Inject constructor(
             return Triple(source, ssh.chosenSessionName!!, ssh.sessionManager)
         }
 
+        val mgr = resolveManagerForPin(source)
+
         // remoteCommand pin (incl. Mosh/ET profiles that skip SessionManager)
         SaveConnectionFromSession.sessionNameFromRemoteCommand(source.remoteCommand)?.let { name ->
-            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
-                ?: SessionManager.TMUX
-            if (mgr != SessionManager.NONE) return Triple(source, name, mgr)
+            return Triple(source, name, mgr)
         }
 
-        // lastSessionName single (reconnect memory) — still a usable pin target
-        val last = source.lastSessionName
+        // lastSessionName: single, or pick the part matching the tab label
+        val lastParts = source.lastSessionName
             ?.split("|")
             ?.map { it.trim() }
             ?.filter { it.isNotEmpty() }
-            ?.singleOrNull()
-        if (last != null) {
-            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
-                ?: preferencesRepository.sessionManager.first().let {
-                    try {
-                        SessionManager.valueOf(it.name)
-                    } catch (_: IllegalArgumentException) {
-                        SessionManager.TMUX
-                    }
-                }
-            if (mgr != SessionManager.NONE) return Triple(source, last, mgr)
+            .orEmpty()
+        if (lastParts.size == 1) {
+            return Triple(source, lastParts[0], mgr)
+        }
+        val tabLabel = tab?.label?.trim().orEmpty()
+        if (lastParts.size > 1 && tabLabel.isNotEmpty()) {
+            val match = lastParts.firstOrNull {
+                it == tabLabel || SessionManager.sanitizeSessionName(it) ==
+                    SessionManager.sanitizeSessionName(tabLabel)
+            }
+            if (match != null) return Triple(source, match, mgr)
         }
 
-        // Tab label last resort (often equals the multiplexer name)
-        val label = tab?.label?.trim()?.takeIf { it.isNotEmpty() }
-        if (label != null) {
-            val mgr = SaveConnectionFromSession.parseSessionManager(source.sessionManager)
-                ?: preferencesRepository.sessionManager.first().let {
-                    try {
-                        SessionManager.valueOf(it.name)
-                    } catch (_: IllegalArgumentException) {
-                        SessionManager.TMUX
-                    }
-                }
-            if (mgr != SessionManager.NONE) {
-                val san = SessionManager.sanitizeSessionName(label)
-                if (san.isNotBlank()) return Triple(source, san, mgr)
-            }
+        // Tab label last resort (often equals the multiplexer / role name)
+        if (tabLabel.isNotEmpty()) {
+            val san = SessionManager.sanitizeSessionName(tabLabel)
+            if (san.isNotBlank()) return Triple(source, san, mgr)
         }
         return null
     }

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -2896,19 +2896,60 @@ class TerminalViewModel @Inject constructor(
     }
 
     /**
+     * Three-layer "where am I?" snapshot for a live terminal tab:
+     * door (connection card), path (transport), room (multiplexer session).
+     */
+    data class ConnectionWhereabouts(
+        val sessionId: String,
+        /** Door — connection profile label. */
+        val doorLabel: String,
+        val doorId: String,
+        val doorHost: String,
+        val doorUser: String,
+        /** Path — SSH / Mosh / Eternal Terminal / … */
+        val pathTransport: String,
+        val pathDetail: String,
+        /** Room — live multiplexer / tab session name when known. */
+        val roomName: String?,
+        /** Room the card's remoteCommand is pinned to (if any). */
+        val roomPinnedOnCard: String?,
+        /** True when live room differs from the card pin. */
+        val roomMismatch: Boolean,
+        val summaryText: String,
+    )
+
+    /**
      * Draft for "Save connection" — pin the live multiplexer session onto a
-     * connection profile (name editable, id stable).
+     * connection profile (name editable, id stable), with door/path/room context.
      */
     data class SaveConnectionUi(
         val draft: SaveConnectionFromSession.Draft,
         val sourceProfileId: String,
+        val doorLabel: String,
+        val pathTransport: String,
+        val roomName: String,
+        val roomPinnedOnCard: String?,
+        val roomMismatch: Boolean,
     )
 
     private val _saveConnectionUi = MutableStateFlow<SaveConnectionUi?>(null)
     val saveConnectionUi: StateFlow<SaveConnectionUi?> = _saveConnectionUi.asStateFlow()
 
+    private val _whereaboutsUi = MutableStateFlow<ConnectionWhereabouts?>(null)
+    val whereaboutsUi: StateFlow<ConnectionWhereabouts?> = _whereaboutsUi.asStateFlow()
+
     fun dismissSaveConnection() {
         _saveConnectionUi.value = null
+    }
+
+    fun dismissWhereabouts() {
+        _whereaboutsUi.value = null
+    }
+
+    /** Details is available for any SSH-family terminal tab. */
+    fun canShowDetails(sessionId: String): Boolean {
+        val tab = _tabs.value.find { it.sessionId == sessionId } ?: return false
+        return tab.transportType in setOf("SSH", "MOSH", "ET")
     }
 
     /**
@@ -2927,6 +2968,19 @@ class TerminalViewModel @Inject constructor(
         return tab.transportType in setOf("SSH", "MOSH", "ET")
     }
 
+    /** Open the Details (where am I?) dialog for [sessionId]. */
+    fun beginShowDetails(sessionId: String) {
+        viewModelScope.launch {
+            val w = buildWhereabouts(sessionId)
+            if (w == null) {
+                _newTabMessage.value =
+                    appContext.getString(R.string.terminal_details_unavailable)
+                return@launch
+            }
+            _whereaboutsUi.value = w
+        }
+    }
+
     /** Open the Save connection confirm dialog for [sessionId]. */
     fun beginSaveConnection(sessionId: String) {
         viewModelScope.launch {
@@ -2938,20 +2992,118 @@ class TerminalViewModel @Inject constructor(
             }
             val (source, sessionName, manager) = pin
             val existing = withContext(Dispatchers.IO) { connectionRepository.getAll() }
+            // Prefer card label as default name when pinning the same room already
+            // on the card; otherwise use the live room name (clearer for new pins).
+            val cardPin = SaveConnectionFromSession.sessionNameFromRemoteCommand(source.remoteCommand)
+            val defaultLabel = when {
+                cardPin != null && cardPin == sessionName && source.label.isNotBlank() -> source.label
+                else -> sessionName
+            }
             val draft = SaveConnectionFromSession.draft(
                 source = source,
                 sessionName = sessionName,
                 manager = manager,
                 existing = existing,
-                defaultLabel = sessionName,
+                defaultLabel = defaultLabel,
             )
             if (draft == null) {
                 _newTabMessage.value =
                     appContext.getString(R.string.terminal_save_connection_need_session)
                 return@launch
             }
-            _saveConnectionUi.value =
-                SaveConnectionUi(draft = draft, sourceProfileId = source.id)
+            val tab = _tabs.value.find { it.sessionId == sessionId }
+            val path = formatTransport(tab?.transportType, source)
+            val mismatch = cardPin != null && cardPin != sessionName
+            _saveConnectionUi.value = SaveConnectionUi(
+                draft = draft,
+                sourceProfileId = source.id,
+                doorLabel = source.label,
+                pathTransport = path,
+                roomName = sessionName,
+                roomPinnedOnCard = cardPin,
+                roomMismatch = mismatch,
+            )
+        }
+    }
+
+    private suspend fun buildWhereabouts(sessionId: String): ConnectionWhereabouts? {
+        val tab = _tabs.value.find { it.sessionId == sessionId } ?: return null
+        if (tab.transportType !in setOf("SSH", "MOSH", "ET")) return null
+        val profile = withContext(Dispatchers.IO) {
+            connectionRepository.getById(tab.profileId)
+        } ?: return null
+        val ssh = sessionManager.getSession(sessionId)
+        val liveRoom = ssh?.chosenSessionName?.takeIf { it.isNotBlank() }
+            ?: SaveConnectionFromSession.sessionNameFromRemoteCommand(profile.remoteCommand)
+            ?: profile.lastSessionName?.split("|")?.map { it.trim() }?.filter { it.isNotEmpty() }?.singleOrNull()
+            ?: tab.label.takeIf { it.isNotBlank() && it != profile.label }
+        val pinned = SaveConnectionFromSession.sessionNameFromRemoteCommand(profile.remoteCommand)
+        val path = formatTransport(tab.transportType, profile)
+        val pathDetail = buildString {
+            append(profile.username)
+            append('@')
+            append(profile.host)
+            append(':')
+            append(profile.port)
+            when {
+                profile.useEternalTerminal -> append(" · etPort ").append(profile.etPort)
+                profile.useMosh -> append(" · mosh")
+            }
+            if (!profile.remoteCommand.isNullOrBlank()) {
+                append("\nremoteCommand: ").append(profile.remoteCommand)
+            }
+        }
+        val mismatch = pinned != null && liveRoom != null &&
+            SessionManager.sanitizeSessionName(pinned) != SessionManager.sanitizeSessionName(liveRoom)
+        val summary = buildString {
+            appendLine("DOOR (card)")
+            appendLine("  ${profile.label}")
+            appendLine("  id ${profile.id}")
+            appendLine("  ${profile.username}@${profile.host}:${profile.port}")
+            appendLine()
+            appendLine("PATH (transport)")
+            appendLine("  $path")
+            appendLine("  ${profile.username}@${profile.host}:${profile.port}")
+            when {
+                profile.useEternalTerminal -> appendLine("  etPort ${profile.etPort}")
+                profile.useMosh -> appendLine("  mosh")
+            }
+            appendLine()
+            appendLine("ROOM (session)")
+            appendLine("  live: ${liveRoom ?: "— unknown —"}")
+            appendLine("  card pin: ${pinned ?: "— none —"}")
+            if (mismatch) appendLine("  ⚠ live room differs from card pin")
+        }.trimEnd()
+        return ConnectionWhereabouts(
+            sessionId = sessionId,
+            doorLabel = profile.label,
+            doorId = profile.id,
+            doorHost = profile.host,
+            doorUser = profile.username,
+            pathTransport = path,
+            pathDetail = pathDetail,
+            roomName = liveRoom,
+            roomPinnedOnCard = pinned,
+            roomMismatch = mismatch,
+            summaryText = summary,
+        )
+    }
+
+    private fun formatTransport(
+        transportType: String?,
+        profile: sh.haven.core.data.db.entities.ConnectionProfile,
+    ): String = when (transportType) {
+        "ET" -> "Eternal Terminal"
+        "MOSH" -> "Mosh"
+        "SSH" -> when {
+            profile.useEternalTerminal -> "Eternal Terminal"
+            profile.useMosh -> "Mosh"
+            else -> "SSH"
+        }
+        else -> transportType ?: when {
+            profile.useEternalTerminal -> "Eternal Terminal"
+            profile.useMosh -> "Mosh"
+            else -> "SSH"
         }
     }
 

--- a/feature/terminal/src/main/res/values/strings.xml
+++ b/feature/terminal/src/main/res/values/strings.xml
@@ -76,6 +76,14 @@
     <string name="terminal_rename_session_title">Rename Session</string>
     <string name="terminal_name">Name</string>
     <string name="terminal_rename">Rename</string>
+
+    <!-- Save connection (pin live session onto a profile for one-tap reconnect) -->
+    <string name="terminal_save_connection">Save connection</string>
+    <string name="terminal_save_connection_title">Save connection</string>
+    <string name="terminal_save_connection_id">ID</string>
+    <string name="terminal_save_connection_saved">Saved connection \"%1$s\"</string>
+    <string name="terminal_save_connection_updated">Updated connection \"%1$s\"</string>
+    <string name="terminal_save_connection_need_session">Attach a multiplexer session first (tmux / zellij / screen / byobu)</string>
     <string name="terminal_enter_fullscreen">Enter fullscreen</string>
     <string name="terminal_exit_fullscreen">Exit fullscreen</string>
     <string name="terminal_vnc_username_label">Username (optional — VeNCrypt only)</string>

--- a/feature/terminal/src/main/res/values/strings.xml
+++ b/feature/terminal/src/main/res/values/strings.xml
@@ -80,10 +80,30 @@
     <!-- Save connection (pin live session onto a profile for one-tap reconnect) -->
     <string name="terminal_save_connection">Save connection</string>
     <string name="terminal_save_connection_title">Save connection</string>
-    <string name="terminal_save_connection_id">ID</string>
+    <string name="terminal_save_connection_id">Profile ID</string>
+    <string name="terminal_save_connection_id_hint">Stable card key — not the room name</string>
+    <string name="terminal_save_connection_name_label">Card name</string>
+    <string name="terminal_save_connection_name_hint">Label on the Connections list (door)</string>
+    <string name="terminal_save_connection_context">Door: %1$s\nPath: %2$s\nRoom to pin: %3$s</string>
+    <string name="terminal_save_connection_mismatch">This card is pinned to room \"%1$s\" but you are in \"%2$s\". Saving will repin the card to the live room.</string>
+    <string name="terminal_save_connection_update">Update pin</string>
     <string name="terminal_save_connection_saved">Saved connection \"%1$s\"</string>
     <string name="terminal_save_connection_updated">Updated connection \"%1$s\"</string>
     <string name="terminal_save_connection_need_session">Couldn\'t detect a session name for this tab. Open a named tmux/zellij/screen session, or set Remote command on the profile, then try Save connection again.</string>
+
+    <!-- Details / where am I (door · path · room) -->
+    <string name="terminal_details">Details</string>
+    <string name="terminal_details_title">Where am I?</string>
+    <string name="terminal_details_door">Door (connection card)</string>
+    <string name="terminal_details_path">Path (transport)</string>
+    <string name="terminal_details_room">Room (tmux / session)</string>
+    <string name="terminal_details_room_unknown">— unknown —</string>
+    <string name="terminal_details_room_pin">Card pin: %1$s</string>
+    <string name="terminal_details_room_no_pin">— none —</string>
+    <string name="terminal_details_room_mismatch">Live room differs from the card pin — you may have entered through a different door or landed in an auto-created session.</string>
+    <string name="terminal_details_copy">Copy</string>
+    <string name="terminal_details_copied">Copied whereabouts</string>
+    <string name="terminal_details_unavailable">Couldn\'t read connection details for this tab.</string>
     <string name="terminal_enter_fullscreen">Enter fullscreen</string>
     <string name="terminal_exit_fullscreen">Exit fullscreen</string>
     <string name="terminal_vnc_username_label">Username (optional — VeNCrypt only)</string>

--- a/feature/terminal/src/main/res/values/strings.xml
+++ b/feature/terminal/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="terminal_save_connection_id">ID</string>
     <string name="terminal_save_connection_saved">Saved connection \"%1$s\"</string>
     <string name="terminal_save_connection_updated">Updated connection \"%1$s\"</string>
-    <string name="terminal_save_connection_need_session">Attach a multiplexer session first (tmux / zellij / screen / byobu)</string>
+    <string name="terminal_save_connection_need_session">Couldn\'t detect a session name for this tab. Open a named tmux/zellij/screen session, or set Remote command on the profile, then try Save connection again.</string>
     <string name="terminal_enter_fullscreen">Enter fullscreen</string>
     <string name="terminal_exit_fullscreen">Exit fullscreen</string>
     <string name="terminal_vnc_username_label">Username (optional — VeNCrypt only)</string>

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
@@ -50,7 +50,8 @@ class SaveConnectionFromSessionTest {
         val local = ssh().copy(connectionType = "LOCAL")
         assertNull(SaveConnectionFromSession.draft(local, "maid", SessionManager.TMUX, emptyList()))
         assertNull(SaveConnectionFromSession.draft(ssh(), "maid", SessionManager.NONE, emptyList()))
-        assertNull(SaveConnectionFromSession.draft(ssh(), "   ", SessionManager.TMUX, emptyList()))
+        // Empty only — whitespace sanitizes to "---", which is a valid session token.
+        assertNull(SaveConnectionFromSession.draft(ssh(), "", SessionManager.TMUX, emptyList()))
     }
 
     @Test

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
@@ -137,6 +137,44 @@ class SaveConnectionFromSessionTest {
     }
 
     @Test
+    fun build_preservesCustomFleetWrapperRemoteCommand() {
+        val wrapper =
+            "bash /home/tin/Central_Command/03_toolkit/bin/haven-role-attach dogfood"
+        val source = ssh(id = "live", label = "seer · Dogfood", useMosh = false).copy(
+            remoteCommand = wrapper,
+        )
+        val existing = listOf(
+            ssh(id = "dogfood", label = "seer · Dogfood", useMosh = true, keyId = "k").copy(
+                remoteCommand = wrapper,
+                lastSessionName = "haven-dogfood",
+            ),
+        )
+        val result = SaveConnectionFromSession.build(
+            source = source,
+            displayName = "seer · Dogfood",
+            sessionName = "haven-dogfood",
+            manager = SessionManager.TMUX,
+            existing = existing,
+            preferredId = "unused",
+        )
+        assertNotNull(result)
+        assertFalse(result!!.created)
+        // Must NOT clobber fleet L4 wrapper with plain tmux pin
+        assertEquals(wrapper, result.profile.remoteCommand)
+        assertEquals("haven-dogfood", result.profile.lastSessionName)
+    }
+
+    @Test
+    fun isStandardMultiplexerPin_distinguishesWrapper() {
+        assertTrue(SaveConnectionFromSession.isStandardMultiplexerPin("tmux new -A -s maid"))
+        assertFalse(
+            SaveConnectionFromSession.isStandardMultiplexerPin(
+                "bash /home/tin/Central_Command/03_toolkit/bin/haven-role-attach dogfood",
+            ),
+        )
+    }
+
+    @Test
     fun build_zellijPin() {
         val result = SaveConnectionFromSession.build(
             source = ssh(),

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/SaveConnectionFromSessionTest.kt
@@ -1,0 +1,167 @@
+package sh.haven.feature.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import sh.haven.core.data.db.entities.ConnectionProfile
+import sh.haven.core.ssh.SessionManager
+
+class SaveConnectionFromSessionTest {
+
+    private fun ssh(
+        id: String = "src",
+        label: String = "sever",
+        host: String = "seer.local",
+        username: String = "tin",
+        port: Int = 22,
+        useMosh: Boolean = true,
+        keyId: String? = "key-1",
+    ) = ConnectionProfile(
+        id = id,
+        label = label,
+        host = host,
+        port = port,
+        username = username,
+        useMosh = useMosh,
+        keyId = keyId,
+        connectionType = "SSH",
+    )
+
+    @Test
+    fun pinRemoteCommand_tmux() {
+        assertEquals("tmux new -A -s Grok-haven", SaveConnectionFromSession.pinRemoteCommand(SessionManager.TMUX, "Grok-haven"))
+    }
+
+    @Test
+    fun pinRemoteCommand_sanitizesDots() {
+        assertEquals("tmux new -A -s user-10-0-0-5", SaveConnectionFromSession.pinRemoteCommand(SessionManager.TMUX, "user@10.0.0.5"))
+    }
+
+    @Test
+    fun pinRemoteCommand_noneIsNull() {
+        assertNull(SaveConnectionFromSession.pinRemoteCommand(SessionManager.NONE, "x"))
+    }
+
+    @Test
+    fun draft_rejectsNonSshAndPlainShell() {
+        val local = ssh().copy(connectionType = "LOCAL")
+        assertNull(SaveConnectionFromSession.draft(local, "maid", SessionManager.TMUX, emptyList()))
+        assertNull(SaveConnectionFromSession.draft(ssh(), "maid", SessionManager.NONE, emptyList()))
+        assertNull(SaveConnectionFromSession.draft(ssh(), "   ", SessionManager.TMUX, emptyList()))
+    }
+
+    @Test
+    fun draft_newProfileGetsFreshId() {
+        val d = SaveConnectionFromSession.draft(
+            source = ssh(),
+            sessionName = "Grok-haven",
+            manager = SessionManager.TMUX,
+            existing = emptyList(),
+            newId = { "new-uuid" },
+        )
+        assertNotNull(d)
+        assertEquals("new-uuid", d!!.profileId)
+        assertEquals("Grok-haven", d.defaultName)
+        assertFalse(d.isUpdate)
+    }
+
+    @Test
+    fun draft_upsertWhenLabelHostUserMatch() {
+        val existing = listOf(ssh(id = "existing", label = "Maid"))
+        val d = SaveConnectionFromSession.draft(
+            source = ssh(label = "other"),
+            sessionName = "maid",
+            manager = SessionManager.TMUX,
+            existing = existing,
+            defaultLabel = "Maid",
+            newId = { "should-not-use" },
+        )
+        assertNotNull(d)
+        assertEquals("existing", d!!.profileId)
+        assertTrue(d.isUpdate)
+    }
+
+    @Test
+    fun build_createsPinnedClone() {
+        val source = ssh(useMosh = true, keyId = "k1")
+        val result = SaveConnectionFromSession.build(
+            source = source,
+            displayName = "Grok",
+            sessionName = "Grok-haven",
+            manager = SessionManager.TMUX,
+            existing = emptyList(),
+            preferredId = "p1",
+        )
+        assertNotNull(result)
+        assertTrue(result!!.created)
+        val p = result.profile
+        assertEquals("p1", p.id)
+        assertEquals("Grok", p.label)
+        assertEquals("tmux new -A -s Grok-haven", p.remoteCommand)
+        assertEquals("Grok-haven", p.lastSessionName)
+        assertEquals("TMUX", p.sessionManager)
+        assertTrue(p.requestPty)
+        assertTrue(p.useMosh)
+        assertEquals("k1", p.keyId)
+        assertNull(p.postLoginCommand)
+    }
+
+    @Test
+    fun build_updatesExistingOnNameCollision() {
+        val source = ssh(id = "live", label = "live-tab", useMosh = false)
+        val existing = listOf(
+            ssh(id = "old", label = "Grok", useMosh = true, keyId = "old-key").copy(
+                remoteCommand = "tmux new -A -s old-name",
+                lastSessionName = "old-name",
+            ),
+        )
+        val result = SaveConnectionFromSession.build(
+            source = source,
+            displayName = "Grok",
+            sessionName = "Grok-haven",
+            manager = SessionManager.TMUX,
+            existing = existing,
+            preferredId = "unused",
+        )
+        assertNotNull(result)
+        assertFalse(result!!.created)
+        assertEquals("old", result.profile.id)
+        assertEquals("tmux new -A -s Grok-haven", result.profile.remoteCommand)
+        assertEquals("Grok-haven", result.profile.lastSessionName)
+        // Live source wins for transport/auth refresh
+        assertFalse(result.profile.useMosh)
+    }
+
+    @Test
+    fun build_zellijPin() {
+        val result = SaveConnectionFromSession.build(
+            source = ssh(),
+            displayName = "z",
+            sessionName = "work",
+            manager = SessionManager.ZELLIJ,
+            existing = emptyList(),
+            preferredId = "z1",
+        )
+        assertEquals("zellij attach work --create", result!!.profile.remoteCommand)
+    }
+
+    @Test
+    fun sessionNameFromRemoteCommand_parsesKnownPins() {
+        assertEquals(
+            "Grok-haven",
+            SaveConnectionFromSession.sessionNameFromRemoteCommand("tmux new -A -s Grok-haven"),
+        )
+        assertEquals(
+            "work",
+            SaveConnectionFromSession.sessionNameFromRemoteCommand("zellij attach work --create"),
+        )
+        assertEquals(
+            "scr",
+            SaveConnectionFromSession.sessionNameFromRemoteCommand("screen -dRR scr"),
+        )
+        assertNull(SaveConnectionFromSession.sessionNameFromRemoteCommand("htop"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Save connection** from a live terminal tab so a multiplexer session can be pinned as a one-tap Connections profile (same idea as hand-edited `remoteCommand` role profiles).

### UX
1. Long-press a terminal tab
2. **Save connection**
3. Dialog: **Name** (editable, default = session name) · **ID** (read-only profile id) · **OK** / **Cancel**
4. OK → upsert profile in Connections (clone host/auth/mosh from live session + pin)

### Behaviour
- Pin via `remoteCommand` (`tmux new -A -s …` / zellij / screen / byobu) + `lastSessionName` + `requestPty`
- Upsert key: same **label + host + username + port** → update pin; else create new UUID
- Distinct from `lastSessionName` reconnect memory (auto remember); this is an explicit save that closes the loop
- Works for SSH session-manager attach and for profiles already using `remoteCommand` / Mosh / ET

### Tests
- Unit tests: `SaveConnectionFromSessionTest` (pin strings, draft/upsert, parse remoteCommand)

## Test plan
- [ ] Connect with session manager (tmux), attach a named session
- [ ] Long-press tab → Save connection → edit name → OK
- [ ] Connections list shows the new card; cold connect auto-attaches without picker
- [ ] Save again with same name updates pin (no duplicate)
- [ ] Cancel leaves DB unchanged
- [ ] CI unit tests green