### PR TITLE
feat(backup): opt-in automatic pull + remember-password + manual-pull shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,7 +77,17 @@
                     android:scheme="haven"
                     android:host="connect" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
+
+        <activity
+            android:name=".backup.PullBackupShortcutActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <!-- One-shot resurrector for the restart_app MCP verb. Runs in its own
              process (:restart) so it can kill the main process — applying a

--- a/app/src/main/kotlin/sh/haven/app/HavenApp.kt
+++ b/app/src/main/kotlin/sh/haven/app/HavenApp.kt
@@ -45,6 +45,7 @@ class HavenApp : Application(), Configuration.Provider {
     @Inject lateinit var sessionManagerRegistry: sh.haven.core.ssh.SessionManagerRegistry
     @Inject lateinit var mailWatchManager: sh.haven.app.agent.mailrules.MailWatchManager
     @Inject lateinit var backupAutoSyncScheduler: sh.haven.app.backup.BackupAutoSyncScheduler
+    @Inject lateinit var backupAutoPullScheduler: sh.haven.app.backup.BackupAutoPullScheduler
     @Inject lateinit var sshTerminalEmulatorOwner: sh.haven.feature.terminal.SshTerminalEmulatorOwner
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -246,6 +247,7 @@ class HavenApp : Application(), Configuration.Provider {
         // Auto-push backup watch (#359) — same pattern: inert until the user
         // enables auto-sync in Settings → Backup → Sync to a remote.
         backupAutoSyncScheduler.start(appScope)
+        backupAutoPullScheduler.start(appScope)
 
         // Extend the shell-prompt terminator set used for command-on-attach
         // detection with the user's custom prompt characters (#280). Replays

--- a/app/src/main/kotlin/sh/haven/app/MainActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/MainActivity.kt
@@ -174,6 +174,7 @@ class MainActivity : AppCompatActivity() {
         handleOpenUsbDriveIntent(intent)
         handleOpenAgentLogExtra(intent)
         handleTaskerRunIntent(intent)
+        handleBackupShortcutIntent(intent)
     }
 
     /**
@@ -393,6 +394,12 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun handleBackupShortcutIntent(intent: Intent?) {
+        if (intent?.action != sh.haven.app.backup.PullBackupShortcutActivity.ACTION_SHOW_BACKUP_PASSWORD_DIALOG) return
+        intent.action = null
+        agentUiCommandBus.emit(sh.haven.core.data.agent.AgentUiCommand.OpenBackupPasswordDialog)
+    }
+
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         KeyEventInterceptor.handler?.let { interceptor ->
             if (interceptor(event)) return true
@@ -410,6 +417,7 @@ class MainActivity : AppCompatActivity() {
         handleOpenUsbDriveIntent(intent)
         handleOpenAgentLogExtra(intent)
         handleTaskerRunIntent(intent)
+        handleBackupShortcutIntent(intent)
         setContent {
             // Tasker overlay run (#367): deferred here so the ConnectionsViewModel
             // is subscribed to the command bus before the coordinator connects.

--- a/app/src/main/kotlin/sh/haven/app/backup/BackupAutoPull.kt
+++ b/app/src/main/kotlin/sh/haven/app/backup/BackupAutoPull.kt
@@ -2,6 +2,8 @@ package sh.haven.app.backup
 
 import android.content.Context
 import android.util.Log
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
@@ -14,9 +16,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import sh.haven.core.data.backup.BackupSyncManager
 import sh.haven.core.data.db.entities.ConnectionLog
 import sh.haven.core.data.preferences.UserPreferencesRepository
@@ -40,7 +45,8 @@ class BackupAutoPullWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
-        if (!preferencesRepository.backupAutoPullEnabled.first()) return Result.success()
+        val isManual = inputData.getBoolean("is_manual", false)
+        if (!isManual && !preferencesRepository.backupAutoPullEnabled.first()) return Result.success()
         val profileId = preferencesRepository.backupSyncProfileId.first() ?: return Result.success()
         val passphrase = preferencesRepository.backupSyncPassphrase() ?: return Result.success()
         val path = preferencesRepository.backupSyncPath.first()
@@ -49,18 +55,33 @@ class BackupAutoPullWorker @AssistedInject constructor(
             val result = backupSyncManager.pull(profileId, path, passphrase)
             val msg = "Restored ${result.count} items" +
                 if (result.errors.isNotEmpty()) " (${result.errors.size} errors)" else ""
+
+            if (isManual) {
+                showNotification(applicationContext, "Backup Sync Success", msg)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(applicationContext, "Backup restored successfully!", Toast.LENGTH_SHORT).show()
+                }
+            }
+
             connectionLogRepository.logEvent(
                 profileId, ConnectionLog.Status.SYNC_OK,
                 durationMs = System.currentTimeMillis() - started,
-                details = "Auto-pull backup ← $path: $msg",
+                details = (if (isManual) "Manual pull" else "Auto-pull") + " backup ← $path: $msg",
             )
             Result.success()
         } catch (e: Exception) {
             Log.w(TAG, "auto-pull failed (attempt $runAttemptCount)", e)
-            if (runAttemptCount >= MAX_ATTEMPTS) {
+            val errorMsg = e.message ?: e.javaClass.simpleName
+            if (isManual) {
+                showNotification(applicationContext, "Backup Sync Failed", errorMsg)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(applicationContext, "Backup pull failed: $errorMsg", Toast.LENGTH_LONG).show()
+                }
+            }
+            if (runAttemptCount >= MAX_ATTEMPTS || isManual) {
                 connectionLogRepository.logEvent(
                     profileId, ConnectionLog.Status.SYNC_FAILED,
-                    details = "Auto-pull backup failed: ${e.message ?: e.javaClass.simpleName}",
+                    details = (if (isManual) "Manual pull" else "Auto-pull") + " backup failed: $errorMsg",
                 )
                 Result.failure()
             } else Result.retry()
@@ -71,18 +92,46 @@ class BackupAutoPullWorker @AssistedInject constructor(
         private const val TAG = "BackupAutoPull"
         private const val UNIQUE_PERIODIC = "backup-auto-pull-periodic"
         private const val MAX_ATTEMPTS = 5
+        private const val BACKUP_CHANNEL_ID = "backup_sync_channel"
 
         private val networked = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 
-        /** Daily periodic pull. */
-        fun schedulePeriodic(context: Context) {
-            val request = PeriodicWorkRequestBuilder<BackupAutoPullWorker>(24, TimeUnit.HOURS)
+        private fun showNotification(context: Context, title: String, message: String) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                if (nm.getNotificationChannel(BACKUP_CHANNEL_ID) == null) {
+                    val channel = android.app.NotificationChannel(
+                        BACKUP_CHANNEL_ID,
+                        "Backup Sync",
+                        android.app.NotificationManager.IMPORTANCE_DEFAULT
+                    )
+                    nm.createNotificationChannel(channel)
+                }
+            }
+            val builder = NotificationCompat.Builder(context, BACKUP_CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_download_done)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true)
+
+            try {
+                nm.notify(424242, builder.build())
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Could not post notification: ${e.message}")
+            }
+        }
+
+        /** Periodic pull. */
+        fun schedulePeriodic(context: Context, intervalMinutes: Int) {
+            val request = PeriodicWorkRequestBuilder<BackupAutoPullWorker>(intervalMinutes.toLong(), TimeUnit.MINUTES)
                 .setConstraints(networked)
                 .build()
             WorkManager.getInstance(context)
-                .enqueueUniquePeriodicWork(UNIQUE_PERIODIC, ExistingPeriodicWorkPolicy.KEEP, request)
+                .enqueueUniquePeriodicWork(UNIQUE_PERIODIC, ExistingPeriodicWorkPolicy.UPDATE, request)
         }
 
         fun cancelAll(context: Context) {
@@ -100,12 +149,17 @@ class BackupAutoPullScheduler @Inject constructor(
 ) {
     fun start(scope: CoroutineScope) {
         scope.launch {
-            preferencesRepository.backupAutoPullEnabled.distinctUntilChanged().collect { enabled ->
+            combine(
+                preferencesRepository.backupAutoPullEnabled.distinctUntilChanged(),
+                preferencesRepository.backupAutoPullIntervalMinutes.distinctUntilChanged()
+            ) { enabled, interval ->
+                enabled to interval
+            }.collect { (enabled, interval) ->
                 if (!enabled) {
                     BackupAutoPullWorker.cancelAll(context)
                     return@collect
                 }
-                BackupAutoPullWorker.schedulePeriodic(context)
+                BackupAutoPullWorker.schedulePeriodic(context, interval)
             }
         }
     }

--- a/app/src/main/kotlin/sh/haven/app/backup/BackupAutoPull.kt
+++ b/app/src/main/kotlin/sh/haven/app/backup/BackupAutoPull.kt
@@ -1,0 +1,112 @@
+package sh.haven.app.backup
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import sh.haven.core.data.backup.BackupSyncManager
+import sh.haven.core.data.db.entities.ConnectionLog
+import sh.haven.core.data.preferences.UserPreferencesRepository
+import sh.haven.core.data.repository.ConnectionLogRepository
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Automatic backup pull from the configured remote (#359 follow-up).
+ *
+ * Mirror structure of BackupAutoSyncWorker but performs a backup pull/restore.
+ */
+@HiltWorker
+class BackupAutoPullWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted params: WorkerParameters,
+    private val preferencesRepository: UserPreferencesRepository,
+    private val backupSyncManager: BackupSyncManager,
+    private val connectionLogRepository: ConnectionLogRepository,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        if (!preferencesRepository.backupAutoPullEnabled.first()) return Result.success()
+        val profileId = preferencesRepository.backupSyncProfileId.first() ?: return Result.success()
+        val passphrase = preferencesRepository.backupSyncPassphrase() ?: return Result.success()
+        val path = preferencesRepository.backupSyncPath.first()
+        return try {
+            val started = System.currentTimeMillis()
+            val result = backupSyncManager.pull(profileId, path, passphrase)
+            val msg = "Restored ${result.count} items" +
+                if (result.errors.isNotEmpty()) " (${result.errors.size} errors)" else ""
+            connectionLogRepository.logEvent(
+                profileId, ConnectionLog.Status.SYNC_OK,
+                durationMs = System.currentTimeMillis() - started,
+                details = "Auto-pull backup ← $path: $msg",
+            )
+            Result.success()
+        } catch (e: Exception) {
+            Log.w(TAG, "auto-pull failed (attempt $runAttemptCount)", e)
+            if (runAttemptCount >= MAX_ATTEMPTS) {
+                connectionLogRepository.logEvent(
+                    profileId, ConnectionLog.Status.SYNC_FAILED,
+                    details = "Auto-pull backup failed: ${e.message ?: e.javaClass.simpleName}",
+                )
+                Result.failure()
+            } else Result.retry()
+        }
+    }
+
+    companion object {
+        private const val TAG = "BackupAutoPull"
+        private const val UNIQUE_PERIODIC = "backup-auto-pull-periodic"
+        private const val MAX_ATTEMPTS = 5
+
+        private val networked = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        /** Daily periodic pull. */
+        fun schedulePeriodic(context: Context) {
+            val request = PeriodicWorkRequestBuilder<BackupAutoPullWorker>(24, TimeUnit.HOURS)
+                .setConstraints(networked)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(UNIQUE_PERIODIC, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+
+        fun cancelAll(context: Context) {
+            WorkManager.getInstance(context).apply {
+                cancelUniqueWork(UNIQUE_PERIODIC)
+            }
+        }
+    }
+}
+
+@Singleton
+class BackupAutoPullScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val preferencesRepository: UserPreferencesRepository,
+) {
+    fun start(scope: CoroutineScope) {
+        scope.launch {
+            preferencesRepository.backupAutoPullEnabled.distinctUntilChanged().collect { enabled ->
+                if (!enabled) {
+                    BackupAutoPullWorker.cancelAll(context)
+                    return@collect
+                }
+                BackupAutoPullWorker.schedulePeriodic(context)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/sh/haven/app/backup/PullBackupShortcutActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/backup/PullBackupShortcutActivity.kt
@@ -3,7 +3,7 @@ package sh.haven.app.backup
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -17,7 +17,7 @@ import sh.haven.core.data.preferences.UserPreferencesRepository
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class PullBackupShortcutActivity : AppCompatActivity() {
+class PullBackupShortcutActivity : ComponentActivity() {
 
     @Inject
     lateinit var preferencesRepository: UserPreferencesRepository

--- a/app/src/main/kotlin/sh/haven/app/backup/PullBackupShortcutActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/backup/PullBackupShortcutActivity.kt
@@ -1,0 +1,55 @@
+package sh.haven.app.backup
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import sh.haven.app.MainActivity
+import sh.haven.core.data.preferences.UserPreferencesRepository
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PullBackupShortcutActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var preferencesRepository: UserPreferencesRepository
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        lifecycleScope.launch {
+            val passphrase = preferencesRepository.backupSyncPassphrase()
+            if (!passphrase.isNullOrEmpty()) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(applicationContext, "Pulling backup in background...", Toast.LENGTH_SHORT).show()
+                }
+                val request = OneTimeWorkRequestBuilder<BackupAutoPullWorker>()
+                    .setInputData(workDataOf("is_manual" to true))
+                    .build()
+                WorkManager.getInstance(applicationContext).enqueue(request)
+            } else {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(applicationContext, "No password saved. Opening Haven...", Toast.LENGTH_SHORT).show()
+                }
+                val intent = Intent(applicationContext, MainActivity::class.java).apply {
+                    action = ACTION_SHOW_BACKUP_PASSWORD_DIALOG
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+                startActivity(intent)
+            }
+            finish()
+        }
+    }
+
+    companion object {
+        const val ACTION_SHOW_BACKUP_PASSWORD_DIALOG = "sh.haven.app.ACTION_SHOW_BACKUP_PASSWORD_DIALOG"
+    }
+}

--- a/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
+++ b/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
@@ -398,6 +398,8 @@ fun HavenNavHost(
                     // Answering the session picker re-drives the attach — same
                     // as ConnectProfile, show the Connections tab.
                     Screen.Connections
+                is sh.haven.core.data.agent.AgentUiCommand.OpenBackupPasswordDialog ->
+                    Screen.Settings
             }
             // Reactive: e.g. OpenRemoteDesktop waits for Desktop to appear
             // rather than silently no-op'ing when it's still hidden.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,4 +326,7 @@
     <string name="tasker_result_exit">%1$s — exit %2$d</string>
     <string name="tasker_result_timed_out">%1$s — timed out</string>
     <string name="tasker_result_failed">%1$s — failed</string>
+
+    <!-- App shortcuts -->
+    <string name="shortcut_pull_backup_label">Pull Backup Now</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="pull_backup_now"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/shortcut_pull_backup_label">
+        <intent
+            android:action="sh.haven.app.ACTION_PULL_BACKUP"
+            android:targetPackage="sh.haven.app"
+            android:targetClass="sh.haven.app.backup.PullBackupShortcutActivity" />
+    </shortcut>
+</shortcuts>

--- a/app/src/test/kotlin/sh/haven/app/backup/BackupAutoPullTest.kt
+++ b/app/src/test/kotlin/sh/haven/app/backup/BackupAutoPullTest.kt
@@ -25,10 +25,15 @@ class BackupAutoPullTest {
     private val preferencesRepository = mockk<UserPreferencesRepository>(relaxed = true)
     private val workManager = mockk<WorkManager>(relaxed = true)
 
+    private val enabledFlow = MutableStateFlow(false)
+    private val intervalFlow = MutableStateFlow(1440)
+
     @Before
     fun setUp() {
         mockkStatic(WorkManager::class)
         every { WorkManager.getInstance(any()) } returns workManager
+        every { preferencesRepository.backupAutoPullEnabled } returns enabledFlow
+        every { preferencesRepository.backupAutoPullIntervalMinutes } returns intervalFlow
     }
 
     @After
@@ -38,8 +43,7 @@ class BackupAutoPullTest {
 
     @Test
     fun `scheduler cancels work when auto-pull is disabled`() = runTest {
-        val enabledFlow = MutableStateFlow(false)
-        every { preferencesRepository.backupAutoPullEnabled } returns enabledFlow
+        enabledFlow.value = false
 
         val scheduler = BackupAutoPullScheduler(context, preferencesRepository)
         val testJob = Job()
@@ -55,8 +59,7 @@ class BackupAutoPullTest {
 
     @Test
     fun `scheduler schedules work when auto-pull is enabled`() = runTest {
-        val enabledFlow = MutableStateFlow(true)
-        every { preferencesRepository.backupAutoPullEnabled } returns enabledFlow
+        enabledFlow.value = true
 
         val scheduler = BackupAutoPullScheduler(context, preferencesRepository)
         val testJob = Job()
@@ -66,6 +69,29 @@ class BackupAutoPullTest {
         runCurrent()
 
         verify(exactly = 1) { workManager.enqueueUniquePeriodicWork("backup-auto-pull-periodic", any(), any()) }
+
+        testJob.cancel()
+    }
+
+    @Test
+    fun `scheduler reschedules work when interval changes`() = runTest {
+        enabledFlow.value = true
+        intervalFlow.value = 1440
+
+        val scheduler = BackupAutoPullScheduler(context, preferencesRepository)
+        val testJob = Job()
+        val childScope = CoroutineScope(coroutineContext + testJob)
+
+        scheduler.start(childScope)
+        runCurrent()
+
+        verify(exactly = 1) { workManager.enqueueUniquePeriodicWork("backup-auto-pull-periodic", any(), any()) }
+
+        // Change interval
+        intervalFlow.value = 60
+        runCurrent()
+
+        verify(exactly = 2) { workManager.enqueueUniquePeriodicWork("backup-auto-pull-periodic", any(), any()) }
 
         testJob.cancel()
     }

--- a/app/src/test/kotlin/sh/haven/app/backup/BackupAutoPullTest.kt
+++ b/app/src/test/kotlin/sh/haven/app/backup/BackupAutoPullTest.kt
@@ -1,0 +1,72 @@
+package sh.haven.app.backup
+
+import android.content.Context
+import androidx.work.WorkManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import sh.haven.core.data.preferences.UserPreferencesRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupAutoPullTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val preferencesRepository = mockk<UserPreferencesRepository>(relaxed = true)
+    private val workManager = mockk<WorkManager>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkStatic(WorkManager::class)
+        every { WorkManager.getInstance(any()) } returns workManager
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(WorkManager::class)
+    }
+
+    @Test
+    fun `scheduler cancels work when auto-pull is disabled`() = runTest {
+        val enabledFlow = MutableStateFlow(false)
+        every { preferencesRepository.backupAutoPullEnabled } returns enabledFlow
+
+        val scheduler = BackupAutoPullScheduler(context, preferencesRepository)
+        val testJob = Job()
+        val childScope = CoroutineScope(coroutineContext + testJob)
+
+        scheduler.start(childScope)
+        runCurrent()
+
+        verify(exactly = 1) { workManager.cancelUniqueWork("backup-auto-pull-periodic") }
+
+        testJob.cancel()
+    }
+
+    @Test
+    fun `scheduler schedules work when auto-pull is enabled`() = runTest {
+        val enabledFlow = MutableStateFlow(true)
+        every { preferencesRepository.backupAutoPullEnabled } returns enabledFlow
+
+        val scheduler = BackupAutoPullScheduler(context, preferencesRepository)
+        val testJob = Job()
+        val childScope = CoroutineScope(coroutineContext + testJob)
+
+        scheduler.start(childScope)
+        runCurrent()
+
+        verify(exactly = 1) { workManager.enqueueUniquePeriodicWork("backup-auto-pull-periodic", any(), any()) }
+
+        testJob.cancel()
+    }
+}

--- a/core/data/src/main/kotlin/sh/haven/core/data/agent/AgentUiCommand.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/agent/AgentUiCommand.kt
@@ -265,4 +265,6 @@ sealed class AgentUiCommand {
         val profileId: String,
         val path: String,
     ) : AgentUiCommand()
+
+    data object OpenBackupPasswordDialog : AgentUiCommand()
 }

--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
@@ -80,6 +80,7 @@ class UserPreferencesRepository @Inject constructor(
     private val backupSyncProfileIdKey = stringPreferencesKey("backup_sync_profile_id")
     private val backupSyncPathKey = stringPreferencesKey("backup_sync_path")
     private val backupAutoSyncEnabledKey = booleanPreferencesKey("backup_auto_sync_enabled")
+    private val backupAutoPullEnabledKey = booleanPreferencesKey("backup_auto_pull_enabled")
     // CredentialEncryption-wrapped backup passphrase for background pushes (#359).
     private val backupSyncPassphraseKey = stringPreferencesKey("backup_sync_passphrase")
     // Session command for the Custom (X11) desktop (#361).
@@ -342,9 +343,59 @@ class UserPreferencesRepository @Inject constructor(
         val encrypted = if (enabled) passphrase?.let { CredentialEncryption.encrypt(context, it) } else null
         dataStore.edit { prefs ->
             prefs[backupAutoSyncEnabledKey] = enabled
-            if (encrypted == null) prefs.remove(backupSyncPassphraseKey)
-            else prefs[backupSyncPassphraseKey] = encrypted
+            if (enabled) {
+                if (encrypted != null) {
+                    prefs[backupSyncPassphraseKey] = encrypted
+                }
+            } else {
+                val autoPullEnabled = prefs[backupAutoPullEnabledKey] ?: false
+                if (!autoPullEnabled) {
+                    prefs.remove(backupSyncPassphraseKey)
+                }
+            }
         }
+    }
+
+    val backupAutoPullEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[backupAutoPullEnabledKey] ?: false
+    }
+
+    suspend fun setBackupAutoPull(enabled: Boolean, passphrase: String?) {
+        val encrypted = if (enabled) passphrase?.let { CredentialEncryption.encrypt(context, it) } else null
+        dataStore.edit { prefs ->
+            prefs[backupAutoPullEnabledKey] = enabled
+            if (enabled) {
+                if (encrypted != null) {
+                    prefs[backupSyncPassphraseKey] = encrypted
+                }
+            } else {
+                val autoSyncEnabled = prefs[backupAutoSyncEnabledKey] ?: false
+                if (!autoSyncEnabled) {
+                    prefs.remove(backupSyncPassphraseKey)
+                }
+            }
+        }
+    }
+
+    suspend fun saveBackupSyncPassphrase(passphrase: String) {
+        val encrypted = CredentialEncryption.encrypt(context, passphrase)
+        dataStore.edit { prefs ->
+            prefs[backupSyncPassphraseKey] = encrypted
+        }
+    }
+
+    suspend fun clearBackupSyncPassphrase() {
+        dataStore.edit { prefs ->
+            val autoSyncEnabled = prefs[backupAutoSyncEnabledKey] ?: false
+            val autoPullEnabled = prefs[backupAutoPullEnabledKey] ?: false
+            if (!autoSyncEnabled && !autoPullEnabled) {
+                prefs.remove(backupSyncPassphraseKey)
+            }
+        }
+    }
+
+    val backupSyncPassphraseFlow: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[backupSyncPassphraseKey]?.let { CredentialEncryption.decrypt(context, it) }
     }
 
     /** The stored auto-sync passphrase, decrypted; null when auto-sync is off. */

--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
@@ -81,6 +81,7 @@ class UserPreferencesRepository @Inject constructor(
     private val backupSyncPathKey = stringPreferencesKey("backup_sync_path")
     private val backupAutoSyncEnabledKey = booleanPreferencesKey("backup_auto_sync_enabled")
     private val backupAutoPullEnabledKey = booleanPreferencesKey("backup_auto_pull_enabled")
+    private val backupAutoPullIntervalMinutesKey = intPreferencesKey("backup_auto_pull_interval_minutes")
     // CredentialEncryption-wrapped backup passphrase for background pushes (#359).
     private val backupSyncPassphraseKey = stringPreferencesKey("backup_sync_passphrase")
     // Session command for the Custom (X11) desktop (#361).
@@ -360,6 +361,10 @@ class UserPreferencesRepository @Inject constructor(
         prefs[backupAutoPullEnabledKey] ?: false
     }
 
+    val backupAutoPullIntervalMinutes: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[backupAutoPullIntervalMinutesKey] ?: 1440
+    }
+
     suspend fun setBackupAutoPull(enabled: Boolean, passphrase: String?) {
         val encrypted = if (enabled) passphrase?.let { CredentialEncryption.encrypt(context, it) } else null
         dataStore.edit { prefs ->
@@ -374,6 +379,12 @@ class UserPreferencesRepository @Inject constructor(
                     prefs.remove(backupSyncPassphraseKey)
                 }
             }
+        }
+    }
+
+    suspend fun setBackupAutoPullInterval(minutes: Int) {
+        dataStore.edit { prefs ->
+            prefs[backupAutoPullIntervalMinutesKey] = minutes
         }
     }
 

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -25845,7 +25845,7 @@
     },
     {
      "name": "settings_backup_auto_sync_hint",
-     "en": "Re-pushes the encrypted backup a couple of minutes after settings change, plus a daily catch-up. Requires storing your backup passphrase (encrypted) on this device so pushes can run in the background. Pull always stays manual.",
+     "en": "Re-pushes the encrypted backup a couple of minutes after settings change, plus a daily catch-up. Requires storing your backup passphrase (encrypted) on this device so pushes can run in the background. Automatic pull is a separate opt-in below.",
      "comment": "Backup section",
      "args": [],
      "t": {

--- a/docs/i18n/strings.json
+++ b/docs/i18n/strings.json
@@ -5469,6 +5469,13 @@
       "ru": "%1$s — ошибка",
       "zh": "%1$s — 失败"
      }
+    },
+    {
+     "name": "shortcut_pull_backup_label",
+     "en": "Pull Backup Now",
+     "comment": "App shortcuts",
+     "args": [],
+     "t": {}
     }
    ]
   },
@@ -25892,6 +25899,76 @@
       "ru": "Задайте пароль, которым будет шифроваться каждая автоматическая резервная копия. Он хранится в зашифрованном виде на этом устройстве — при отключении автоотправки он удаляется.",
       "zh": "设置用于加密每次自动备份的密码。它加密保存在本设备上——关闭自动推送即会删除。"
      }
+    },
+    {
+     "name": "settings_backup_auto_pull_label",
+     "en": "Pull automatically",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_hint",
+     "en": "Periodically pulls the latest backup and restores it. If you also edit connections on this device, unsaved local changes can be overwritten (remote is last-write-wins).",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_dialog_title",
+     "en": "Enable automatic pull",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_dialog_description",
+     "en": "Enter the backup passphrase. It is kept encrypted on this device to pull backups in the background — turning auto-pull off deletes it.",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_interval_label",
+     "en": "Pull interval",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_interval_15m",
+     "en": "15 minutes",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_interval_1h",
+     "en": "1 hour",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_interval_6h",
+     "en": "6 hours",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_auto_pull_interval_24h",
+     "en": "24 hours",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
+    },
+    {
+     "name": "settings_backup_remember_password_label",
+     "en": "Remember this password",
+     "comment": "Backup section",
+     "args": [],
+     "t": {}
     },
     {
      "name": "settings_export_backup_title",

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
@@ -1782,7 +1782,7 @@ fun SettingsScreen(
 
     showBackupPasswordDialog?.let { action ->
         BackupPasswordDialog(
-            isExport = action !is BackupAction.Restore && action !is BackupAction.PullRemote,
+            isExport = action !is BackupAction.Restore && action !is BackupAction.PullRemote && action !is BackupAction.EnableAutoPull,
             titleOverride = when (action) {
                 is BackupAction.EnableAutoSync -> stringResource(R.string.settings_backup_auto_sync_dialog_title)
                 is BackupAction.EnableAutoPull -> stringResource(R.string.settings_backup_auto_pull_dialog_title)

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
@@ -80,6 +80,7 @@ import androidx.compose.material.icons.filled.FontDownload
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -1772,17 +1773,24 @@ fun SettingsScreen(
         )
     }
 
+    val backupSyncPassphrase by viewModel.backupSyncPassphrase.collectAsState()
+
     showBackupPasswordDialog?.let { action ->
         BackupPasswordDialog(
             isExport = action !is BackupAction.Restore && action !is BackupAction.PullRemote,
-            titleOverride = if (action is BackupAction.EnableAutoSync) {
-                stringResource(R.string.settings_backup_auto_sync_dialog_title)
-            } else null,
-            descriptionOverride = if (action is BackupAction.EnableAutoSync) {
-                stringResource(R.string.settings_backup_auto_sync_dialog_description)
-            } else null,
+            titleOverride = when (action) {
+                is BackupAction.EnableAutoSync -> stringResource(R.string.settings_backup_auto_sync_dialog_title)
+                is BackupAction.EnableAutoPull -> stringResource(R.string.settings_backup_auto_pull_dialog_title)
+                else -> null
+            },
+            descriptionOverride = when (action) {
+                is BackupAction.EnableAutoSync -> stringResource(R.string.settings_backup_auto_sync_dialog_description)
+                is BackupAction.EnableAutoPull -> stringResource(R.string.settings_backup_auto_pull_dialog_description)
+                else -> null
+            },
+            initialPassword = backupSyncPassphrase ?: "",
             onDismiss = { showBackupPasswordDialog = null },
-            onConfirm = { password ->
+            onConfirm = { password, remember ->
                 showBackupPasswordDialog = null
                 when (action) {
                     is BackupAction.Export -> {
@@ -1790,16 +1798,29 @@ fun SettingsScreen(
                         exportLauncher.launch("haven-backup.enc")
                     }
                     is BackupAction.Restore -> {
+                        if (remember) {
+                            viewModel.saveBackupSyncPassphrase(password)
+                        } else {
+                            viewModel.clearBackupSyncPassphrase()
+                        }
                         viewModel.importBackup(action.uri, password)
                     }
                     is BackupAction.PushRemote -> {
                         viewModel.pushBackupToRemote(password)
                     }
                     is BackupAction.PullRemote -> {
+                        if (remember) {
+                            viewModel.saveBackupSyncPassphrase(password)
+                        } else {
+                            viewModel.clearBackupSyncPassphrase()
+                        }
                         viewModel.pullBackupFromRemote(password)
                     }
                     is BackupAction.EnableAutoSync -> {
                         viewModel.setBackupAutoSync(true, password)
+                    }
+                    is BackupAction.EnableAutoPull -> {
+                        viewModel.setBackupAutoPull(true, password)
                     }
                 }
             },
@@ -1811,11 +1832,13 @@ fun SettingsScreen(
         val syncProfileId by viewModel.backupSyncProfileId.collectAsState()
         val syncPath by viewModel.backupSyncPath.collectAsState()
         val autoSyncEnabled by viewModel.backupAutoSyncEnabled.collectAsState()
+        val autoPullEnabled by viewModel.backupAutoPullEnabled.collectAsState()
         BackupSyncDialog(
             candidates = syncCandidates,
             selectedProfileId = syncProfileId,
             path = syncPath,
             autoSyncEnabled = autoSyncEnabled,
+            autoPullEnabled = autoPullEnabled,
             onDestinationChange = { pid, p -> viewModel.setBackupSyncDestination(pid, p) },
             onAutoSyncChange = { enable ->
                 if (enable) {
@@ -1823,6 +1846,14 @@ fun SettingsScreen(
                     showBackupPasswordDialog = BackupAction.EnableAutoSync
                 } else {
                     viewModel.setBackupAutoSync(false, null)
+                }
+            },
+            onAutoPullChange = { enable ->
+                if (enable) {
+                    showBackupSyncDialog = false
+                    showBackupPasswordDialog = BackupAction.EnableAutoPull
+                } else {
+                    viewModel.setBackupAutoPull(false, null)
                 }
             },
             onPush = {
@@ -1924,6 +1955,7 @@ private sealed interface BackupAction {
 
     /** Turning on auto-push (#359): collects the passphrase the background job will encrypt with. */
     data object EnableAutoSync : BackupAction
+    data object EnableAutoPull : BackupAction
 }
 
 /**
@@ -1939,8 +1971,10 @@ private fun BackupSyncDialog(
     selectedProfileId: String?,
     path: String,
     autoSyncEnabled: Boolean,
+    autoPullEnabled: Boolean,
     onDestinationChange: (String?, String) -> Unit,
     onAutoSyncChange: (Boolean) -> Unit,
+    onAutoPullChange: (Boolean) -> Unit,
     onPush: () -> Unit,
     onPull: () -> Unit,
     onDismiss: () -> Unit,
@@ -2024,6 +2058,24 @@ private fun BackupSyncDialog(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    Spacer(Modifier.height(12.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = stringResource(R.string.settings_backup_auto_pull_label),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Switch(
+                            checked = autoPullEnabled,
+                            onCheckedChange = onAutoPullChange,
+                            enabled = hasDestination || autoPullEnabled,
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.settings_backup_auto_pull_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         },
@@ -2047,12 +2099,14 @@ private fun BackupSyncDialog(
 private fun BackupPasswordDialog(
     isExport: Boolean,
     onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit,
+    onConfirm: (String, Boolean) -> Unit,
     titleOverride: String? = null,
     descriptionOverride: String? = null,
+    initialPassword: String = "",
 ) {
-    var password by remember { mutableStateOf("") }
+    var password by remember(initialPassword) { mutableStateOf(initialPassword) }
     var confirmPassword by remember { mutableStateOf("") }
+    var rememberPassword by remember(initialPassword) { mutableStateOf(initialPassword.isNotEmpty()) }
     val title = titleOverride
         ?: stringResource(if (isExport) R.string.settings_backup_export_dialog_title else R.string.settings_backup_restore_dialog_title)
     val passwordError = if (isExport && password.length in 1..5) stringResource(R.string.settings_backup_password_min_length) else null
@@ -2095,11 +2149,30 @@ private fun BackupPasswordDialog(
                         supportingText = confirmError,
                         modifier = Modifier.fillMaxWidth(),
                     )
+                } else {
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { rememberPassword = !rememberPassword }
+                            .padding(vertical = 4.dp)
+                    ) {
+                        Checkbox(
+                            checked = rememberPassword,
+                            onCheckedChange = { rememberPassword = it }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.settings_backup_remember_password_label),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
                 }
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(password) }, enabled = canConfirm) {
+            TextButton(onClick = { onConfirm(password, rememberPassword) }, enabled = canConfirm) {
                 Text(stringResource(if (isExport) R.string.settings_backup_export_button else R.string.settings_backup_restore_button))
             }
         },

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
@@ -258,6 +258,11 @@ fun SettingsScreen(
     var showBackupSyncDialog by remember { mutableStateOf(false) }
     var showLockTimeoutDialog by remember { mutableStateOf(false) }
     var showOsc133SetupDialog by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        viewModel.openBackupPasswordDialogEvent.collect {
+            showBackupPasswordDialog = BackupAction.PullRemote
+        }
+    }
     var showScreenOrderDialog by remember { mutableStateOf(false) }
     val screenOrder by viewModel.screenOrder.collectAsState()
 
@@ -1833,12 +1838,14 @@ fun SettingsScreen(
         val syncPath by viewModel.backupSyncPath.collectAsState()
         val autoSyncEnabled by viewModel.backupAutoSyncEnabled.collectAsState()
         val autoPullEnabled by viewModel.backupAutoPullEnabled.collectAsState()
+        val autoPullIntervalMinutes by viewModel.backupAutoPullIntervalMinutes.collectAsState()
         BackupSyncDialog(
             candidates = syncCandidates,
             selectedProfileId = syncProfileId,
             path = syncPath,
             autoSyncEnabled = autoSyncEnabled,
             autoPullEnabled = autoPullEnabled,
+            autoPullIntervalMinutes = autoPullIntervalMinutes,
             onDestinationChange = { pid, p -> viewModel.setBackupSyncDestination(pid, p) },
             onAutoSyncChange = { enable ->
                 if (enable) {
@@ -1855,6 +1862,9 @@ fun SettingsScreen(
                 } else {
                     viewModel.setBackupAutoPull(false, null)
                 }
+            },
+            onAutoPullIntervalChange = { minutes ->
+                viewModel.setBackupAutoPullInterval(minutes)
             },
             onPush = {
                 showBackupSyncDialog = false
@@ -1972,9 +1982,11 @@ private fun BackupSyncDialog(
     path: String,
     autoSyncEnabled: Boolean,
     autoPullEnabled: Boolean,
+    autoPullIntervalMinutes: Int,
     onDestinationChange: (String?, String) -> Unit,
     onAutoSyncChange: (Boolean) -> Unit,
     onAutoPullChange: (Boolean) -> Unit,
+    onAutoPullIntervalChange: (Int) -> Unit,
     onPush: () -> Unit,
     onPull: () -> Unit,
     onDismiss: () -> Unit,
@@ -2071,6 +2083,45 @@ private fun BackupSyncDialog(
                             enabled = hasDestination || autoPullEnabled,
                         )
                     }
+                    if (autoPullEnabled) {
+                        Spacer(Modifier.height(8.dp))
+                        var intervalExpanded by remember { mutableStateOf(false) }
+                        val intervals = listOf(15, 60, 360, 1440)
+                        val intervalLabels = mapOf(
+                            15 to stringResource(R.string.settings_backup_auto_pull_interval_15m),
+                            60 to stringResource(R.string.settings_backup_auto_pull_interval_1h),
+                            360 to stringResource(R.string.settings_backup_auto_pull_interval_6h),
+                            1440 to stringResource(R.string.settings_backup_auto_pull_interval_24h)
+                        )
+                        ExposedDropdownMenuBox(
+                            expanded = intervalExpanded,
+                            onExpandedChange = { intervalExpanded = it },
+                        ) {
+                            OutlinedTextField(
+                                value = intervalLabels[autoPullIntervalMinutes] ?: intervalLabels[1440]!!,
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text(stringResource(R.string.settings_backup_auto_pull_interval_label)) },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(intervalExpanded) },
+                                modifier = Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = intervalExpanded,
+                                onDismissRequest = { intervalExpanded = false }
+                            ) {
+                                intervals.forEach { minutes ->
+                                    DropdownMenuItem(
+                                        text = { Text(intervalLabels[minutes] ?: "") },
+                                        onClick = {
+                                            onAutoPullIntervalChange(minutes)
+                                            intervalExpanded = false
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(4.dp))
                     Text(
                         text = stringResource(R.string.settings_backup_auto_pull_hint),
                         style = MaterialTheme.typography.bodySmall,

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
@@ -241,6 +241,24 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { preferencesRepository.setBackupAutoSync(enabled, passphrase) }
     }
 
+    val backupAutoPullEnabled: StateFlow<Boolean> = preferencesRepository.backupAutoPullEnabled
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setBackupAutoPull(enabled: Boolean, passphrase: String?) {
+        viewModelScope.launch { preferencesRepository.setBackupAutoPull(enabled, passphrase) }
+    }
+
+    val backupSyncPassphrase: StateFlow<String?> = preferencesRepository.backupSyncPassphraseFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    fun saveBackupSyncPassphrase(passphrase: String) {
+        viewModelScope.launch { preferencesRepository.saveBackupSyncPassphrase(passphrase) }
+    }
+
+    fun clearBackupSyncPassphrase() {
+        viewModelScope.launch { preferencesRepository.clearBackupSyncPassphrase() }
+    }
+
     /** Encrypt the config and write it to the configured remote. */
     fun pushBackupToRemote(password: String) {
         val profileId = backupSyncProfileId.value

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
@@ -44,7 +44,20 @@ class SettingsViewModel @Inject constructor(
     private val connectionRepository: ConnectionRepository,
     private val mcpStatusHolder: sh.haven.core.data.agent.McpStatusHolder,
     private val biometricGate: sh.haven.core.data.keystore.BiometricGate,
+    private val agentUiCommandBus: sh.haven.core.data.agent.AgentUiCommandBus,
 ) : ViewModel() {
+
+    val openBackupPasswordDialogEvent = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(replay = 0)
+
+    init {
+        viewModelScope.launch {
+            agentUiCommandBus.commands.collect { command ->
+                if (command is sh.haven.core.data.agent.AgentUiCommand.OpenBackupPasswordDialog) {
+                    openBackupPasswordDialogEvent.emit(Unit)
+                }
+            }
+        }
+    }
 
     /**
      * Non-null when the WireGuard-exposed MCP endpoint is shadowed by another
@@ -246,6 +259,13 @@ class SettingsViewModel @Inject constructor(
 
     fun setBackupAutoPull(enabled: Boolean, passphrase: String?) {
         viewModelScope.launch { preferencesRepository.setBackupAutoPull(enabled, passphrase) }
+    }
+
+    val backupAutoPullIntervalMinutes: StateFlow<Int> = preferencesRepository.backupAutoPullIntervalMinutes
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 1440)
+
+    fun setBackupAutoPullInterval(minutes: Int) {
+        viewModelScope.launch { preferencesRepository.setBackupAutoPullInterval(minutes) }
     }
 
     val backupSyncPassphrase: StateFlow<String?> = preferencesRepository.backupSyncPassphraseFlow

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -148,6 +148,11 @@
     <string name="settings_backup_auto_pull_hint">Periodically pulls the latest backup and restores it. If you also edit connections on this device, unsaved local changes can be overwritten (remote is last-write-wins).</string>
     <string name="settings_backup_auto_pull_dialog_title">Enable automatic pull</string>
     <string name="settings_backup_auto_pull_dialog_description">Enter the backup passphrase. It is kept encrypted on this device to pull backups in the background — turning auto-pull off deletes it.</string>
+    <string name="settings_backup_auto_pull_interval_label">Pull interval</string>
+    <string name="settings_backup_auto_pull_interval_15m">15 minutes</string>
+    <string name="settings_backup_auto_pull_interval_1h">1 hour</string>
+    <string name="settings_backup_auto_pull_interval_6h">6 hours</string>
+    <string name="settings_backup_auto_pull_interval_24h">24 hours</string>
     <string name="settings_backup_remember_password_label">Remember this password</string>
     <string name="settings_export_backup_title">Export backup</string>
     <string name="settings_export_backup_subtitle">Keys, connections, and settings</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="settings_backup_sync_push_button">Push</string>
     <string name="settings_backup_sync_pull_button">Pull</string>
     <string name="settings_backup_auto_sync_label">Push automatically</string>
-    <string name="settings_backup_auto_sync_hint">Re-pushes the encrypted backup a couple of minutes after settings change, plus a daily catch-up. Requires storing your backup passphrase (encrypted) on this device so pushes can run in the background. Pull always stays manual.</string>
+    <string name="settings_backup_auto_sync_hint">Re-pushes the encrypted backup a couple of minutes after settings change, plus a daily catch-up. Requires storing your backup passphrase (encrypted) on this device so pushes can run in the background. Automatic pull is a separate opt-in below.</string>
     <string name="settings_backup_auto_sync_dialog_title">Enable automatic push</string>
     <string name="settings_backup_auto_sync_dialog_description">Set the passphrase that will encrypt every automatic backup. It is kept encrypted on this device — turning auto-push off deletes it.</string>
     <string name="settings_backup_auto_pull_label">Pull automatically</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_backup_auto_sync_hint">Re-pushes the encrypted backup a couple of minutes after settings change, plus a daily catch-up. Requires storing your backup passphrase (encrypted) on this device so pushes can run in the background. Pull always stays manual.</string>
     <string name="settings_backup_auto_sync_dialog_title">Enable automatic push</string>
     <string name="settings_backup_auto_sync_dialog_description">Set the passphrase that will encrypt every automatic backup. It is kept encrypted on this device — turning auto-push off deletes it.</string>
+    <string name="settings_backup_auto_pull_label">Pull automatically</string>
+    <string name="settings_backup_auto_pull_hint">Periodically pulls the latest backup and restores it. If you also edit connections on this device, unsaved local changes can be overwritten (remote is last-write-wins).</string>
+    <string name="settings_backup_auto_pull_dialog_title">Enable automatic pull</string>
+    <string name="settings_backup_auto_pull_dialog_description">Enter the backup passphrase. It is kept encrypted on this device to pull backups in the background — turning auto-pull off deletes it.</string>
+    <string name="settings_backup_remember_password_label">Remember this password</string>
     <string name="settings_export_backup_title">Export backup</string>
     <string name="settings_export_backup_subtitle">Keys, connections, and settings</string>
     <string name="settings_restore_backup_title">Restore backup</string>


### PR DESCRIPTION
## Summary

Backup sync currently supports automatic **push** (#359) but pull stays manual by design — the original rationale (see `BackupAutoSync.kt`) is that an unattended pull could silently overwrite local edits on a last-write-wins remote. That tradeoff doesn't fit every setup: if a device is a pure *consumer* of a backup authored elsewhere (a headless "source of truth" host), automatic pull is safe and saves a manual step every time the source changes.

This PR adds automatic pull as a **separate, off-by-default opt-in** alongside the existing push toggle — it doesn't touch push's behavior or its warning copy (well, it does — see below).

- **"Pull automatically" toggle** in the backup sync dialog, next to the existing "Push automatically" toggle. Off by default. Enabling it prompts for the backup passphrase (stored encrypted on-device, same mechanism as auto-push) and schedules a periodic `WorkManager` pull.
- **Configurable interval** — 15 minutes / 1 hour / 6 hours / 24 hours (15m is WorkManager's platform floor; the periodic worker reschedules cleanly when the interval changes).
- **"Remember this password" checkbox** on the manual Restore Backup dialog, reusing the same encrypted-passphrase field auto-pull already uses (no second storage location). Unchecked by default; when checked, the password field pre-fills on the next manual restore without re-typing — restore still requires tapping Restore, keeping it an eyes-open action.
- **Static Android App Shortcut** ("Pull Backup Now", long-press the launcher icon) — runs a one-off pull in the background using the already-remembered passphrase, reporting success/failure via Toast + notification. If no passphrase is saved yet, it opens the app straight to the restore-password dialog instead of failing silently.
- Fixed a stale line in the push-automatically hint ("Pull always stays manual") that this PR makes inaccurate — it now points at the new toggle instead.

## Two bugs found via on-device testing (not just unit tests)

1. The shared password dialog's `isExport` flag didn't exclude the new `EnableAutoPull` action, so turning on "Pull automatically" incorrectly demanded a *new* password + confirmation instead of the *existing* backup passphrase — the toggle was unusable as shipped in an earlier revision of this PR. Fixed by adding `EnableAutoPull` to the same exclusion as `Restore`/`PullRemote`.
2. The App Shortcut activity crashed on tap (`IllegalStateException: You need to use a Theme.AppCompat theme...`) — it extended `AppCompatActivity` but the manifest used the plain platform theme `Theme.Translucent.NoTitleBar` (matching `RestartActivity`, which is a plain `Activity` and doesn't need AppCompat). Switched the base class to `ComponentActivity`, keeping `lifecycleScope` without the AppCompat theme requirement.

Both were caught live on a physical device (not just `assembleDebug`/unit tests), then fixed and re-verified on-device.

## Testing

- `:app:testX64DebugUnitTest` (`BackupAutoPullTest`, including a new test for interval-change rescheduling) — passing.
- `:app:assembleArm64Debug` — clean build, CI green (build/test/lint/checks) after the fixes above.
- Manual on-device verification: enabled auto-pull with the fixed dialog (single password field + remember checkbox, matching Restore's UX), selected each interval option, triggered the App Shortcut with and without a saved passphrase (correct fallback to the password dialog when unset), confirmed the worker enqueues and reports success/failure via Toast without crashing.