### PR TITLE
fix(backup): don't crash when the stored auto-pull passphrase can't be decrypted

### DIFF
--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import sh.haven.core.security.CredentialEncryption
+import java.security.GeneralSecurityException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -408,12 +409,23 @@ class UserPreferencesRepository @Inject constructor(
     }
 
     val backupSyncPassphraseFlow: Flow<String?> = dataStore.data.map { prefs ->
-        prefs[backupSyncPassphraseKey]?.let { CredentialEncryption.decrypt(context, it) }
+        prefs[backupSyncPassphraseKey]?.let { decryptSyncPassphraseOrNull(it) }
     }
 
-    /** The stored auto-sync passphrase, decrypted; null when auto-sync is off. */
+    /** The stored auto-sync passphrase, decrypted; null when auto-sync is off or the
+     *  stored ciphertext can no longer be decrypted (e.g. the Android Keystore key
+     *  didn't survive an app reinstall / device restore — Keystore keys are excluded
+     *  from Android's own backup mechanism by design, so a restored DataStore file
+     *  can carry ciphertext its own Keystore will never decrypt again). */
     suspend fun backupSyncPassphrase(): String? =
-        dataStore.data.first()[backupSyncPassphraseKey]?.let { CredentialEncryption.decrypt(context, it) }
+        dataStore.data.first()[backupSyncPassphraseKey]?.let { decryptSyncPassphraseOrNull(it) }
+
+    private fun decryptSyncPassphraseOrNull(encrypted: String): String? =
+        try {
+            CredentialEncryption.decrypt(context, encrypted)
+        } catch (e: GeneralSecurityException) {
+            null
+        }
 
     /**
      * Emits the current state on collect and again on every preferences write —


### PR DESCRIPTION
## Summary

Found this live on a real device while testing #458 (auto-pull) end to end: the app crash-loops on every launch with `java.security.GeneralSecurityException: decryption failed` from `CredentialEncryption.decrypt()`, thrown uncaught inside `UserPreferencesRepository.backupSyncPassphraseFlow` / `backupSyncPassphrase()`, which `BackupAutoPullScheduler.start()` collects from `HavenApp.onCreate()`.

**Root cause:** the stored passphrase ciphertext is Android Keystore-backed, and Keystore keys are deliberately excluded from Android's own app-data backup/restore mechanism. An app reinstall or device data restore can leave the old encrypted DataStore value behind while the Keystore key itself doesn't survive — so it can never be decrypted again. This isn't specific to any one backup file; it's a real scenario any user can hit (reinstall, new device, etc.), and once it happens the app becomes unusable until the user clears app data.

**Fix:** treat an undecryptable stored passphrase the same as "none configured" instead of letting the exception propagate. Wrapped in a small private helper so both the `Flow` and the suspend accessor share the same handling.

## Test plan
- [x] Reproduced the crash on a real device with a stored (undecryptable) passphrase
- [x] Applied the fix, confirmed the app no longer crashes on launch with the same device state
- [x] CI green on this branch: build, test, lint, checks, nightly-abi (x64 + armv7), release-r8-smoke, supply-chain all pass

Note: an unrelated flaky test (`SshlibExecContractTest`, module `core:ssh`, a real-SSH-server integration test) is not touched by this change.