### PR TITLE
Fix deep link profile matching and warm-start support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity>
+
+        <activity
+            android:name=".DeepLinkActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
             <!-- step-ca renewal notification deep-link: tapping the
                  "cert expiring" notification fires haven://renew-cert/<keyId>
                  which lands here, then the activity hands the keyId off to
@@ -77,9 +88,6 @@
                     android:scheme="haven"
                     android:host="connect" />
             </intent-filter>
-            <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity

--- a/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
+++ b/app/src/main/kotlin/sh/haven/app/ConnectDeepLink.kt
@@ -26,22 +26,26 @@ object ConnectDeepLink {
         val session: String?,
         /** Optional remote command (Tin attach / clean tmux). `command` or `startupCommand` query. */
         val command: String? = null,
+        val id: String? = null,
     )
 
     /**
      * Build [Params] from a query-parameter getter (e.g. `uri::getQueryParameter`).
-     * Returns null when no `host` is present — a connect link without a host
-     * is a no-op rather than an error.
+     * Returns null when no `host` (and no `id`) is present — a connect link without
+     * a host or id is a no-op rather than an error.
      */
     fun parse(query: (String) -> String?): Params? {
-        val host = query("host")?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val host = query("host")?.trim()?.takeIf { it.isNotEmpty() }
+        val id = query("id")?.trim()?.takeIf { it.isNotEmpty() }
+        if (host == null && id == null) return null
         return Params(
-            host = host,
+            host = host ?: "",
             username = query("user")?.trim()?.takeIf { it.isNotEmpty() },
             port = query("port")?.trim()?.toIntOrNull(),
             transport = query("transport")?.trim()?.lowercase()?.takeIf { it.isNotEmpty() },
             session = query("session")?.trim()?.takeIf { it.isNotEmpty() },
             command = (query("command") ?: query("startupCommand"))?.trim()?.takeIf { it.isNotEmpty() },
+            id = id,
         )
     }
 
@@ -57,13 +61,39 @@ object ConnectDeepLink {
         }
 
     /** Saved profiles whose host (and any supplied user/port/transport) match [p]. */
-    fun matches(profiles: List<ConnectionProfile>, p: Params): List<ConnectionProfile> =
-        profiles.filter { prof ->
+    fun matches(profiles: List<ConnectionProfile>, p: Params): List<ConnectionProfile> {
+        if (p.id != null) {
+            return profiles.filter { it.id == p.id }
+        }
+        val candidates = profiles.filter { prof ->
             prof.host.equals(p.host, ignoreCase = true) &&
                 (p.username == null || prof.username.equals(p.username, ignoreCase = true)) &&
                 (p.port == null || prof.port == p.port) &&
                 (p.transport == null || matchesTransport(prof, p.transport))
         }
+        if (candidates.size <= 1) {
+            return candidates
+        }
+        val narrowCandidates = candidates.filter { prof ->
+            val cmd = prof.remoteCommand
+            if (cmd == null) {
+                false
+            } else {
+                val matchSession = p.session == null || cmd.contains(p.session, ignoreCase = true)
+                val matchCommand = p.command == null || cmd.contains(p.command, ignoreCase = true)
+                if (p.session == null && p.command == null) {
+                    false
+                } else {
+                    matchSession && matchCommand
+                }
+            }
+        }
+        return if (narrowCandidates.size == 1) {
+            narrowCandidates
+        } else {
+            candidates
+        }
+    }
 
     /**
      * The command to emit for [p]: connect a single matched profile, otherwise

--- a/app/src/main/kotlin/sh/haven/app/DeepLinkActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/DeepLinkActivity.kt
@@ -1,0 +1,22 @@
+package sh.haven.app
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+class DeepLinkActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val data = intent?.data
+        if (data != null) {
+            val forwardIntent = Intent(this, MainActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+                setData(data)
+                // Add flags to ensure the intent is delivered to MainActivity and calls onNewIntent()
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+            startActivity(forwardIntent)
+        }
+        finish()
+    }
+}

--- a/app/src/main/kotlin/sh/haven/app/DeepLinkActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/DeepLinkActivity.kt
@@ -9,10 +9,14 @@ class DeepLinkActivity : Activity() {
         super.onCreate(savedInstanceState)
         val data = intent?.data
         if (data != null) {
+            val activeActivity = MainActivity.getActiveInstance()
+            if (activeActivity != null) {
+                activeActivity.handleDeepLinkUri(data)
+            }
             val forwardIntent = Intent(this, MainActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
                 setData(data)
-                // Add flags to ensure the intent is delivered to MainActivity and calls onNewIntent()
+                // Add flags to ensure the intent is delivered to MainActivity
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
             startActivity(forwardIntent)

--- a/app/src/main/kotlin/sh/haven/app/MainActivity.kt
+++ b/app/src/main/kotlin/sh/haven/app/MainActivity.kt
@@ -408,6 +408,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        activeInstanceRef = java.lang.ref.WeakReference(this)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         handleWorkspaceShortcut(intent)
@@ -562,6 +563,26 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    override fun onDestroy() {
+        if (activeInstanceRef?.get() === this) {
+            activeInstanceRef = null
+        }
+        super.onDestroy()
+    }
+
+    fun handleDeepLinkUri(uri: android.net.Uri) {
+        val intent = Intent().apply { data = uri }
+        handleRenewCertDeepLink(intent)
+        handleConnectDeepLink(intent)
+    }
+
+    companion object {
+        @Volatile
+        private var activeInstanceRef: java.lang.ref.WeakReference<MainActivity>? = null
+
+        fun getActiveInstance(): MainActivity? = activeInstanceRef?.get()
     }
 }
 

--- a/app/src/test/kotlin/sh/haven/app/ConnectDeepLinkTest.kt
+++ b/app/src/test/kotlin/sh/haven/app/ConnectDeepLinkTest.kt
@@ -158,4 +158,53 @@ class ConnectDeepLinkTest {
         val cmd = ConnectDeepLink.resolve(listOf(a, b), ConnectDeepLink.Params("h", "me", null, null, null))
         assertTrue(cmd is AgentUiCommand.PrefillNewConnection)
     }
+
+    @Test
+    fun `parse extracts id param`() {
+        val p = ConnectDeepLink.parse(query("host" to "h", "id" to "uuid-123"))!!
+        assertEquals("uuid-123", p.id)
+    }
+
+    @Test
+    fun `parse allows host to be missing when id is present`() {
+        val p = ConnectDeepLink.parse(query("id" to "uuid-123"))!!
+        assertEquals("uuid-123", p.id)
+        assertEquals("", p.host)
+    }
+
+    @Test
+    fun `matches handles exact match by id parameter`() {
+        val a = profile(id = "a", host = "h", username = "me")
+        val b = profile(id = "b", host = "h", username = "me")
+        val all = listOf(a, b)
+        
+        // matching with id="b" should return only "b", bypassing any ambiguity on host/user
+        val p = ConnectDeepLink.Params(host = "h", username = "me", port = null, transport = null, session = null, id = "b")
+        val result = ConnectDeepLink.matches(all, p)
+        assertEquals(1, result.size)
+        assertEquals("b", result[0].id)
+    }
+
+    @Test
+    fun `matches narrows ambiguous candidates using remoteCommand session and command substring match`() {
+        val a = profile(id = "a", host = "h", username = "me").copy(remoteCommand = "exec tmux new -s sess-a")
+        val b = profile(id = "b", host = "h", username = "me").copy(remoteCommand = "exec tmux new -s sess-b")
+        val all = listOf(a, b)
+
+        // If session = "sess-b", it should narrow to "b"
+        val p = ConnectDeepLink.Params(host = "h", username = "me", port = null, transport = null, session = "sess-b")
+        val result = ConnectDeepLink.matches(all, p)
+        assertEquals(1, result.size)
+        assertEquals("b", result[0].id)
+    }
+
+    @Test
+    fun `resolve connects exact match by id when candidates are ambiguous on host-user-port`() {
+        val a = profile(id = "a", host = "h", username = "me")
+        val b = profile(id = "b", host = "h", username = "me")
+        val cmd = ConnectDeepLink.resolve(listOf(a, b), ConnectDeepLink.Params("h", "me", null, null, null, null, "b"))
+        assertTrue(cmd is AgentUiCommand.ConnectFromDeepLink)
+        cmd as AgentUiCommand.ConnectFromDeepLink
+        assertEquals("b", cmd.profileId)
+    }
 }


### PR DESCRIPTION
This PR resolves two deep link issues:

### (a) Fix profile matching when host/user/port are identical (Fixes #305)
- Adds an `id=` parameter to correctly match profiles even when the host, user, and port are identical.

### (b) Fix deep link warm-start support
- Implements a `DeepLinkActivity` trampoline and a static `WeakReference` callback to `MainActivity` to ensure deep links function correctly when the app is already open (warm-start).
- Verified on a physical Seeker device for both warm-start and cold-start scenarios.

This is a clean pull request containing only the 5 files related to deep link logic, replacing #481 and #483 which were closed due to accidental pollution from the fork's main branch.
