### PR TITLE
fix(terminal): reliably paste uploaded file path after Attach flow

### DIFF
--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -409,8 +409,32 @@ fun TerminalScreen(
                 text
             }
             tab.sendInput(payload.toByteArray())
+        } else {
+            viewModel.showNewTabMessage(context.getString(R.string.terminal_paste_no_active_tab))
         }
         viewModel.consumeScanInjection()
+    }
+
+    // Inject the uploaded file's remote path at the cursor on the active
+    // tab once the Attach → "Send a file" flow finishes, honouring
+    // bracket-paste the same way pendingScanInjection does above. Drains
+    // the StateFlow via consumeAttachInjection so a second attach doesn't
+    // fire on recomposition.
+    val pendingAttachInjection by viewModel.pendingAttachInjection.collectAsState()
+    LaunchedEffect(pendingAttachInjection) {
+        val text = pendingAttachInjection ?: return@LaunchedEffect
+        val tab = viewModel.tabs.value.getOrNull(viewModel.activeTabIndex.value)
+        if (tab != null) {
+            val payload = if (tab.bracketPasteMode.value) {
+                "[200~$text[201~"
+            } else {
+                text
+            }
+            tab.sendInput(payload.toByteArray())
+        } else {
+            viewModel.showNewTabMessage(context.getString(R.string.terminal_paste_no_active_tab))
+        }
+        viewModel.consumeAttachInjection()
     }
 
     // Read at composition time — stringResource is @Composable and so

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -350,8 +350,7 @@ class TerminalViewModel @Inject constructor(
                 fileSize = fileSize,
                 initialProfileId = initialProfileId,
             ) ?: return@launch
-            val tab = _tabs.value.getOrNull(_activeTabIndex.value) ?: return@launch
-            tab.sendInput(payload.toByteArray())
+            _pendingAttachInjection.value = payload
         }
     }
 
@@ -368,6 +367,11 @@ class TerminalViewModel @Inject constructor(
     private val _pendingScanInjection = MutableStateFlow<String?>(null)
     val pendingScanInjection: StateFlow<String?> = _pendingScanInjection.asStateFlow()
     fun consumeScanInjection() { _pendingScanInjection.value = null }
+
+    /** Same as [pendingScanInjection], but for the Attach → "Send a file" flow. */
+    private val _pendingAttachInjection = MutableStateFlow<String?>(null)
+    val pendingAttachInjection: StateFlow<String?> = _pendingAttachInjection.asStateFlow()
+    fun consumeAttachInjection() { _pendingAttachInjection.value = null }
 
     /**
      * Decode [sourceUri] into a bitmap, hand it to the appropriate scan
@@ -2326,6 +2330,7 @@ class TerminalViewModel @Inject constructor(
     private val _newTabMessage = MutableStateFlow<String?>(null)
     val newTabMessage: StateFlow<String?> = _newTabMessage.asStateFlow()
     fun dismissNewTabMessage() { _newTabMessage.value = null }
+    fun showNewTabMessage(message: String) { _newTabMessage.value = message }
 
     /**
      * FIDO2/security-key touch/PIN prompt, surfaced so the terminal screen can

--- a/feature/terminal/src/main/res/values/strings.xml
+++ b/feature/terminal/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="terminal_copy_last_output">Copy last output</string>
     <string name="terminal_copied_output">Copied output (%d chars)</string>
     <string name="terminal_no_command_output">No command output found (needs shell integration)</string>
+    <string name="terminal_paste_no_active_tab">No active tab to paste into</string>
     <string name="terminal_link_open_failed">No app can open this link</string>
     <string name="terminal_link_scheme_blocked">Blocked link (unsupported scheme)</string>
     <string name="terminal_local_vnc_failed">Couldn\'t start the local desktop</string>


### PR DESCRIPTION
Clean replacement for #534, per @GlassOnTin's review — same fix, based straight off `upstream/main` (no fork-state noise this time).

## Summary
- The Attach → "Send a file" flow uploaded correctly via SFTP, but the remote path silently never landed in the terminal — `tab.sendInput(...)` was called directly from inside the coroutine launched by `runAttachFlow`, racing against Compose recomposition/navigation back to the Terminal screen.
- Fix: route the payload through a `pendingAttachInjection` StateFlow drained by a `LaunchedEffect` in the screen — the same shape `pendingScanInjection` already uses for the QR/barcode scan feature — applying bracket-paste the same way.
- Also added a toast (`terminal_paste_no_active_tab`) instead of silently dropping the payload if no active tab exists when either injection fires — a latent gap the existing scan-injection path had too.
- Left the existing scan payload's bracket-paste escape literal untouched, per your note that the raw-byte and `` spellings are equivalent at runtime and not worth touching in this diff.

## Test plan
- [x] Manual repro on a physical device with a debug APK built from this fix: Attach → Send a file → pick file → Choose folder → Use this folder → path now pastes at the terminal cursor, bracket-paste wrapped when the shell has it enabled.
- [ ] No automated test yet for `runAttachFlow` — happy to add one alongside the existing scan-injection test if you'd like it as a condition for merge.
