### PR TITLE
fix(ssh): keepalive intervals via JSch setters + proactive probe before SFTP list

### DIFF
--- a/core/ssh/src/main/kotlin/sh/haven/core/ssh/SshSessionManager.kt
+++ b/core/ssh/src/main/kotlin/sh/haven/core/ssh/SshSessionManager.kt
@@ -840,14 +840,16 @@ class SshSessionManager @Inject constructor(
      *    owns those via its own watchdog and probing here would race its reconnect,
      *  - sessions whose profile policy disables autoReconnect.
      */
-    suspend fun probeAndReconnectStale(probeTimeoutMs: Long = 5_000L) {
+    suspend fun probeAndReconnectStale(probeTimeoutMs: Long = 5_000L, profileId: String? = null) {
         val candidates = _sessions.value.values.filter {
             it.status == SessionState.Status.CONNECTED &&
                 !it.headless &&
-                it.connectionConfig?.reconnectPolicy?.autoReconnect == true
+                it.connectionConfig?.reconnectPolicy?.autoReconnect == true &&
+                (profileId == null || it.profileId == profileId)
         }
         if (candidates.isEmpty()) return
-        Log.d(TAG, "probeAndReconnectStale: probing ${candidates.size} live session(s)")
+        Log.d(TAG, "probeAndReconnectStale: probing ${candidates.size} live session(s)" +
+            (profileId?.let { " for profile $it" } ?: ""))
         coroutineScope {
             candidates.map { session ->
                 async {

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -4771,6 +4772,45 @@ class SftpViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 if (!pasteInProgress.get()) _loading.value = true
+
+                // Probe active sessions and reconnect if stale/dead — a
+                // socket can die silently while the app stays foregrounded
+                // (NAT/carrier timeout with no lifecycle transition to
+                // trigger the return-to-foreground probe in
+                // SshConnectionService), and reusing it here throws
+                // "session is down" while the empty-state text still reads
+                // "Empty directory". Probe first so this is transparent.
+                sessionManager.probeAndReconnectStale(profileId = profileId)
+
+                // A profile whose SSH/Mosh/ET session just opened for the
+                // first time can still be CONNECTING when this runs (e.g.
+                // right after tapping the connection card) — wait briefly
+                // for the handshake to resolve on whichever transport the
+                // profile actually uses, instead of racing it and landing
+                // on an empty/home fallback.
+                val profile = repository.getById(profileId)
+                withTimeoutOrNull(5_000) {
+                    when {
+                        profile?.isMosh == true -> {
+                            moshSessionManager.sessions.first { sessions ->
+                                sessions.values.filter { it.profileId == profileId }
+                                    .let { forProfile -> forProfile.isEmpty() || forProfile.any { it.status != MoshSessionManager.SessionState.Status.CONNECTING } }
+                            }
+                        }
+                        profile?.isEternalTerminal == true -> {
+                            etSessionManager.sessions.first { sessions ->
+                                sessions.values.filter { it.profileId == profileId }
+                                    .let { forProfile -> forProfile.isEmpty() || forProfile.any { it.status != EtSessionManager.SessionState.Status.CONNECTING } }
+                            }
+                        }
+                        else -> {
+                            sessionManager.sessions.first { sessions ->
+                                sessions.values.filter { it.profileId == profileId }
+                                    .let { forProfile -> forProfile.isEmpty() || forProfile.any { it.status != SessionState.Status.CONNECTING } }
+                            }
+                        }
+                    }
+                }
 
                 // SSH/SFTP calls below open or write to channels over the
                 // network, so they must run off the Main dispatcher.


### PR DESCRIPTION
Follow-up to #535 (same repro, different bug found while investigating). Branched clean off `upstream/main`.

## Summary
Repro: a long-lived SSH connection sits idle while the app stays in the foreground the whole time (no background/foreground transition) — the underlying socket dies to a NAT/carrier idle timeout, but the app keeps showing CONNECTED. Opening the Files tab reuses the dead session and throws `session is down`.

Two related fixes:
- `SshOptionsApplier` forwarded a per-profile `ServerAliveInterval`/`ServerAliveCountMax` override into JSch's `setConfig(Hashtable)`, which JSch silently ignores for those two fields — the override never took effect. Now calls `session.setServerAliveInterval()`/`setServerAliveCountMax()` directly. Verified both existing `SshClient` call sites already invoke this before `connect()`, so ordering is safe. Also raised the hardcoded default from 15s to 20s.
- `openSftpAndList()` now calls the existing `sessionManager.probeAndReconnectStale()` before listing a directory. That probe already exists and is wired to return-to-foreground, but a NAT-idle-timeout death with the app never leaving the foreground never triggers it — this makes opening the tab itself a trigger too, so the existing reconnect-with-backoff runs instead of surfacing a raw exception.

Deliberately did NOT add a background watchdog/polling coroutine for this — considered and rejected (relies on a stale `isConnected()` boolean, gets suspended by Doze right when it'd matter, and duplicates what `probeAndReconnectStale()` already does properly).

## Test plan
- [x] Manually verified on the actual device that first surfaced this bug (idle repro, then opening Files) — no more stale "session is down"/Empty directory.
- [ ] No automated test added for `probeAndReconnectStale()` being called from `openSftpAndList()` — happy to add one if wanted.
