### PR TITLE
Fix IME input dropping repeated control bytes

### DIFF
--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -169,18 +169,42 @@ internal class EmulatorWriteBuffer(
 }
 
 /**
- * Coalesces rapid single-byte inputs into a batch, then deduplicates only
- * the exact IME double-fire pattern (buffer == [X, X]).
+ * Applies the historical IME double-fire workaround to a batch of
+ * single-byte terminal input.
  *
- * Android IMEs often fire both commitText and sendKeyEvent for the same
+ * Only duplicate printable ASCII bytes are eligible for deduplication.
+ * Control bytes must be preserved because repeated control characters
+ * can be intentional terminal input. In particular, Vietnamese Gboard
+ * replacement can legitimately emit two consecutive DEL (0x7F) bytes.
+ */
+internal fun normalizeCoalescedInput(buffer: List<Byte>): ByteArray {
+    val isImeDedupCandidate =
+        buffer.size == 2 &&
+            buffer[0] == buffer[1] &&
+            (buffer[0].toInt() and 0xFF) in 0x20..0x7E
+
+    return if (isImeDedupCandidate) {
+        byteArrayOf(buffer[0])
+    } else {
+        buffer.toByteArray()
+    }
+}
+
+/**
+ * Coalesces rapid single-byte inputs into a batch and applies the historical
+ * IME double-fire workaround to exactly two identical printable ASCII bytes.
+ *
+ * Android IMEs may fire both commitText and sendKeyEvent for the same
  * keystroke, causing onKeyboardInput to be called twice with the same byte.
  * Both calls happen within a single Handler message, so a posted Runnable
  * flushes after all input from the current message is processed.
  *
- * The IME double-fire signature: exactly 2 identical bytes in the buffer.
- * Paste "aa" also matches this, but that's a rare edge case compared to
- * the constant double-fire on every keystroke. Longer paste sequences
- * (e.g., "aab", "43339") are preserved correctly.
+ * Repeated control bytes are intentionally preserved. They can represent
+ * legitimate terminal input; for example, Vietnamese Gboard replacement may
+ * emit two consecutive DEL (0x7F) bytes before sending replacement text.
+ *
+ * Paste "aa" still matches the printable-ASCII heuristic, while longer input
+ * sequences such as "aab" and "43339" are preserved.
  *
  * Multi-byte inputs (toolbar, escape sequences) bypass coalescing.
  */
@@ -214,12 +238,7 @@ private class InputCoalescer(private val sink: (ByteArray) -> Unit) {
         val bytes: ByteArray
         synchronized(buffer) {
             if (buffer.isEmpty()) return
-            // IME double-fire signature: exactly 2 identical bytes
-            if (buffer.size == 2 && buffer[0] == buffer[1]) {
-                bytes = byteArrayOf(buffer[0])
-            } else {
-                bytes = buffer.toByteArray()
-            }
+            bytes = normalizeCoalescedInput(buffer)
             buffer.clear()
         }
         sink(bytes)

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/InputCoalescerTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/InputCoalescerTest.kt
@@ -1,0 +1,87 @@
+package sh.haven.feature.terminal
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class InputCoalescerTest {
+
+    @Test
+    fun `Vietnamese IME replacement preserves two DEL bytes`() {
+        val input = listOf(
+            0x7F.toByte(),
+            0x7F.toByte(),
+        )
+
+        val output = normalizeCoalescedInput(input)
+
+        assertArrayEquals(
+            byteArrayOf(
+                0x7F.toByte(),
+                0x7F.toByte(),
+            ),
+            output,
+        )
+    }
+
+    @Test
+    fun `historical duplicate printable ASCII workaround is preserved`() {
+        val input = listOf(
+            'a'.code.toByte(),
+            'a'.code.toByte(),
+        )
+
+        val output = normalizeCoalescedInput(input)
+
+        assertArrayEquals(
+            byteArrayOf('a'.code.toByte()),
+            output,
+        )
+    }
+
+    @Test
+    fun `repeated control bytes are never deduplicated`() {
+        val controls = listOf(
+            0x03, // Ctrl-C
+            0x09, // TAB
+            0x0D, // CR / Enter
+            0x1B, // ESC
+            0x7F, // DEL / Backspace
+        )
+
+        for (value in controls) {
+            val b = value.toByte()
+
+            assertArrayEquals(
+                "control byte 0x%02X must be preserved twice".format(value),
+                byteArrayOf(b, b),
+                normalizeCoalescedInput(listOf(b, b)),
+            )
+        }
+    }
+
+    @Test
+    fun `different printable bytes are preserved`() {
+        val input = listOf(
+            'a'.code.toByte(),
+            'b'.code.toByte(),
+        )
+
+        assertArrayEquals(
+            byteArrayOf(
+                'a'.code.toByte(),
+                'b'.code.toByte(),
+            ),
+            normalizeCoalescedInput(input),
+        )
+    }
+
+    @Test
+    fun `three identical printable bytes are preserved`() {
+        val a = 'a'.code.toByte()
+
+        assertArrayEquals(
+            byteArrayOf(a, a, a),
+            normalizeCoalescedInput(listOf(a, a, a)),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Preserve repeated terminal control bytes in `InputCoalescer` while keeping
the existing IME double-fire workaround for duplicate printable ASCII input.

This fixes incorrect Vietnamese text composition with Gboard in Haven's SSH
terminal, where composed text could appear duplicated, for example:

`độc lập` -> `đôộc lâập`

## Observed behavior

I initially compared the same Vietnamese Gboard input in two Android terminal
apps.

In Moshi, Gboard produced the expected text correctly:

`độc lập`

In Haven, however, Vietnamese composition produced a characteristic duplication
pattern, for example:

`đôộc lâập`

Visually, it looked as if Gboard was replacing an existing character sequence,
but Haven was failing to fully remove the old characters before inserting the
replacement text.

Because of that behavior, the initial suspicion was an Android
IME/InputConnection issue in Haven, possibly around `replaceText()` handling.

However, further instrumentation showed that Gboard, `InputConnection`,
`ImeInputView`, and `KeyboardHandler` were all producing the correct replacement
sequence.

The actual loss happened later in the terminal input pipeline.

## Root cause

Vietnamese Gboard performs composition by replacing previously entered
characters.

For example, while composing:

`đôc` -> `độc`

Gboard replaces the trailing `ôc` with `ộc`.

Haven correctly generated two consecutive DEL (`0x7F`) bytes to remove the two
existing characters, followed by the UTF-8 bytes for the replacement text.

The intended terminal input was therefore:

`7F 7F` + `ộc`

Instrumentation confirmed that both DEL events reached `KeyboardHandler`.

However, `InputCoalescer` contained a historical IME double-fire workaround
that deduplicated any batch containing exactly two identical single-byte inputs.

As a result:

`7F 7F` -> `7F`

Only one DEL reached the remote SSH PTY.

Instead of removing both `ô` and `c`, the terminal removed only `c`, leaving:

`đô`

Then the replacement text `ộc` was appended:

`đô` + `ộc` -> `đôộc`

The same underlying behavior could produce other duplicated Vietnamese
composition results such as:

`lâập`

So the original symptom resembled an IME/InputConnection replacement bug, but
the actual root cause was the byte deduplication heuristic in
`InputCoalescer`.

## Fix

Restrict the historical IME double-fire deduplication heuristic to exactly two
identical printable ASCII bytes (`0x20..0x7E`).

Repeated control bytes are now preserved.

This means input such as:

`aa` -> `a`

continues to use the existing IME double-fire workaround, while legitimate
terminal control input such as:

`7F 7F` -> `7F 7F`

is no longer modified.

This also preserves repeated control bytes such as DEL, TAB, CR, ESC, and
Ctrl-C.

## Verification

Verified on a physical Android device using Gboard Vietnamese over an SSH
terminal session.

Before the fix, while composing `độc`, the remote PTY received:

`64 7F C4 91 6F 7F C3 B4 63 7F E1 BB 99 63`

The final replacement sequence contained only one DEL before `ộc`.

After the fix, the remote PTY receives:

`64 7F C4 91 6F 7F C3 B4 63 7F 7F E1 BB 99 63`

The two consecutive DEL bytes are now preserved correctly.

In particular, the final part changed from:

Before:

`63 7F E1 BB 99 63`

to:

After:

`63 7F 7F E1 BB 99 63`

The second `0x7F` now reaches the remote SSH PTY correctly, and Vietnamese
Gboard composition produces the expected text instead of duplicated output.

## Tests

Added regression tests covering:

- two consecutive DEL bytes are preserved
- repeated control bytes are preserved
- duplicate printable ASCII still uses the existing workaround
- different printable bytes are preserved
- three identical printable bytes are preserved

Full terminal unit test suite:

```text
./gradlew :feature:terminal:testDebugUnitTest

BUILD SUCCESSFUL