### PR TITLE
fix(terminal): distinguish IME double-fire from genuine repeated input

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "termlib"]
 	path = termlib
-	url = https://github.com/GlassOnTin/termlib.git
+	url = https://github.com/binhdnguyen/termlib.git
 	branch = main
 [submodule "mosh-kotlin"]
 	path = mosh-kotlin

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -169,42 +169,27 @@ internal class EmulatorWriteBuffer(
 }
 
 /**
- * Applies the historical IME double-fire workaround to a batch of
- * single-byte terminal input.
+ * Flushes a coalesced single-byte input batch.
  *
- * Only duplicate printable ASCII bytes are eligible for deduplication.
- * Control bytes must be preserved because repeated control characters
- * can be intentional terminal input. In particular, Vietnamese Gboard
- * replacement can legitimately emit two consecutive DEL (0x7F) bytes.
+ * IME double-fire (commitText plus a raw view key) is suppressed in
+ * ImeInputView, not here. This function must not drop repeated printable
+ * ASCII or repeated control bytes: genuine "aa", paste of "aa", and
+ * Vietnamese Gboard replacement DELs (0x7F 0x7F) are all intentional.
  */
 internal fun normalizeCoalescedInput(buffer: List<Byte>): ByteArray {
-    val isImeDedupCandidate =
-        buffer.size == 2 &&
-            buffer[0] == buffer[1] &&
-            (buffer[0].toInt() and 0xFF) in 0x20..0x7E
-
-    return if (isImeDedupCandidate) {
-        byteArrayOf(buffer[0])
-    } else {
-        buffer.toByteArray()
-    }
+    return buffer.toByteArray()
 }
 
 /**
- * Coalesces rapid single-byte inputs into a batch and applies the historical
- * IME double-fire workaround to exactly two identical printable ASCII bytes.
+ * Coalesces rapid single-byte inputs into one SSH write.
  *
- * Android IMEs may fire both commitText and sendKeyEvent for the same
- * keystroke, causing onKeyboardInput to be called twice with the same byte.
- * Both calls happen within a single Handler message, so a posted Runnable
- * flushes after all input from the current message is processed.
+ * A posted Runnable flushes after the current Handler message, so a
+ * burst of 1-byte onKeyboardInput callbacks (IME paste iteration,
+ * per-codepoint dispatch) becomes a single sink() call.
  *
- * Repeated control bytes are intentionally preserved. They can represent
- * legitimate terminal input; for example, Vietnamese Gboard replacement may
- * emit two consecutive DEL (0x7F) bytes before sending replacement text.
- *
- * Paste "aa" still matches the printable-ASCII heuristic, while longer input
- * sequences such as "aab" and "43339" are preserved.
+ * Duplicate printable input is no longer guessed here. Gboard's
+ * commitText+raw-key echo is dropped in ImeInputView where the
+ * callback identity still exists.
  *
  * Multi-byte inputs (toolbar, escape sequences) bypass coalescing.
  */
@@ -226,9 +211,8 @@ private class InputCoalescer(private val sink: (ByteArray) -> Unit) {
             buffer.add(data[0])
         }
 
-        // Post flush to run after the current message completes.
-        // Both IME double-fire calls and paste iteration happen within
-        // one message, so the flush sees the complete batch.
+        // Post flush after the current message so a burst of 1-byte
+        // callbacks is written as one sink() call.
         handler.removeCallbacks(flushRunnable)
         handler.post(flushRunnable)
     }

--- a/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/InputCoalescerTest.kt
+++ b/feature/terminal/src/test/kotlin/sh/haven/feature/terminal/InputCoalescerTest.kt
@@ -24,7 +24,7 @@ class InputCoalescerTest {
     }
 
     @Test
-    fun `historical duplicate printable ASCII workaround is preserved`() {
+    fun `genuine repeated printable ASCII is preserved`() {
         val input = listOf(
             'a'.code.toByte(),
             'a'.code.toByte(),
@@ -33,7 +33,10 @@ class InputCoalescerTest {
         val output = normalizeCoalescedInput(input)
 
         assertArrayEquals(
-            byteArrayOf('a'.code.toByte()),
+            byteArrayOf(
+                'a'.code.toByte(),
+                'a'.code.toByte(),
+            ),
             output,
         )
     }


### PR DESCRIPTION
Follow-up to #587.

#587 correctly stopped collapsing repeated control bytes (Vietnamese Gboard `7F 7F`). The remaining printable-ASCII heuristic still dropped a genuine `"aa"` that landed in one coalescer batch.

This stops guessing at `InputCoalescer`. Gboard's `commitText` + raw-key echo is dropped in `ImeInputView`, where the callback identity exists. `normalizeCoalescedInput` is now a passthrough.

While testing Vietnamese Gboard over SSH, two more IME/terminal desyncs showed up and are included:

- Backspace deleted on the PTY but left the InputConnection `Editable` stale, so Telex kept composing against `getTextBeforeCursor` ghosts. User DEL now shrinks the Editable by one code point (#99: the whole buffer is still not wiped).
- Hold-backspace died after a syllable because `restartInput` tore down Gboard's repeat. Backspace no longer restarts the IME; if Gboard goes silent while DEL is still down, Haven continues sending DEL until `ACTION_UP`.

## termlib
Most of the IME-layer work lives in the `termlib` submodule:

https://github.com/GlassOnTin/termlib/compare/main...binhdnguyen:termlib:fix/gboard-ime-echo-and-backspace

The submodule URL on this branch temporarily points at `binhdnguyen/termlib` so CI can fetch SHA `8a9a689`. After the companion termlib PR merges, that URL can go back to `GlassOnTin/termlib` and the SHA can be retargeted.

## Tests
- `./gradlew :feature:terminal:testDebugUnitTest --tests sh.haven.feature.terminal.InputCoalescerTest` — 5/5 (`[a,a]` preserved; `7F 7F` and other controls still pass through)
- termlib `ImeInputViewTest` — 90/90
- Physical Android device with Gboard Vietnamese over SSH (echo `"aa"`, Telex after delete, hold-backspace)

## Tests that fail if reverted
- `genuine repeated printable ASCII is preserved` fails if the old `[X,X]→[X]` heuristic returns
- `testTypeNullRawViewEventAfterCommitTextIsEchoSuppressed` fails if the echo is delivered twice
- `testTypeNullRawKeyAfterEchoDrainIsGenuineRepeat` fails if a later keystroke is treated as echo